### PR TITLE
add logic to handle multiple pages of events

### DIFF
--- a/data/sample_search_page.html
+++ b/data/sample_search_page.html
@@ -1,0 +1,4162 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML+RDFa 1.1//EN">
+<html lang="en" dir="ltr" version="HTML+RDFa 1.1" xmlns:content="http://purl.org/rss/1.0/modules/content/"
+    xmlns:dc="http://purl.org/dc/terms/" xmlns:foaf="http://xmlns.com/foaf/0.1/"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:sioc="http://rdfs.org/sioc/ns#"
+    xmlns:sioct="http://rdfs.org/sioc/types#" xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+
+<head profile="http://www.w3.org/1999/xhtml/vocab">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <link rel="shortcut icon" href="https://www.pdga.com/sites/all/themes/pdga/favicon.ico"
+        type="image/vnd.microsoft.icon" />
+    <meta name="viewport"
+        content="width=device-width, initial-scale=1, maximum-scale=3, minimum-scale=1, user-scalable=yes" />
+    <meta name="description"
+        content="The PDGA is the professional association for ALL disc golfers and the source for disc golf courses, tournament results, and the official rules of disc golf." />
+    <meta name="keywords"
+        content="disc golf, disc golf players, disc golf tournaments, disc golf leagues, disc golf courses, disc golf rules, disc golf statistics, disc golf results" />
+    <link rel="canonical" href="https://www.pdga.com/tour/search" />
+    <link rel="shortlink" href="https://www.pdga.com/tour/search" />
+    <meta property="fb:app_id" content="121305337967028" />
+    <meta property="og:site_name" content="Professional Disc Golf Association" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://www.pdga.com/tour/search" />
+    <meta property="og:title" content="Disc Golf Event Search" />
+    <meta property="og:description"
+        content="The PDGA is the professional association for ALL disc golfers and the source for disc golf courses, tournament results, and the official rules of disc golf." />
+    <meta property="og:image"
+        content="https://www.pdga.com/files/styles/homepage_carousel/public/new_era_hero_img2x.jpg" />
+    <meta property="og:image:secure_url"
+        content="https://www.pdga.com/files/styles/homepage_carousel/public/new_era_hero_img2x.jpg" />
+    <meta property="og:image:alt" content="PDGA logo over landscape with basket" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="650" />
+    <meta property="og:image:height" content="370" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:url" content="https://www.pdga.com/tour/search" />
+    <meta name="twitter:title" content="Disc Golf Event Search" />
+    <meta itemprop="name" content="Disc Golf Event Search" />
+    <meta name="dcterms.title" content="Disc Golf Event Search" />
+    <meta name="dcterms.type" content="Text" />
+    <meta name="dcterms.format" content="text/html" />
+    <meta name="dcterms.identifier" content="https://www.pdga.com/tour/search" />
+    <title>Disc Golf Event Search | Professional Disc Golf Association</title>
+    <link type="text/css" rel="stylesheet"
+        href="https://www.pdga.com/files/css/css_xE-rWrJf-fncB6ztZfd2huxqgxu4WO-qwma6Xer30m4.css" media="all" />
+    <link type="text/css" rel="stylesheet"
+        href="https://www.pdga.com/files/css/css_5f4mTlQnReQiD_8uSxMd2TX4P_QtCNAWVM8tXSUfjo8.css" media="all" />
+    <link type="text/css" rel="stylesheet"
+        href="https://www.pdga.com/files/css/css_BhaJxf5-cG4phkCd4P6QJl_57Df4Xg1wCmQNoxjYGxI.css" media="all" />
+    <link type="text/css" rel="stylesheet"
+        href="https://www.pdga.com/files/css/css_YdIq3TfefEG9Sw1mN7sdKOerZNwRkC6_rWBZ38IpXos.css" media="all" />
+    <link type="text/css" rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Montserrat:wght@500;700&amp;display=swap" media="all" />
+    <link type="text/css" rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,500;1,500&amp;display=swap"
+        media="all" />
+    <link type="text/css" rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@48,400,1,0"
+        media="all" />
+    <link type="text/css" rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
+        media="all" />
+    <link type="text/css" rel="stylesheet"
+        href="https://www.pdga.com/files/css/css_0NoVphkIVaZWK5Tf_j02NBF8P9fx9-sdU6AGCZ0JDCc.css" media="all" />
+    <link type="text/css" rel="stylesheet"
+        href="https://www.pdga.com/files/css/css_Vgeysrd_hR3hM7GNhzBPLqa08xRMMn6zjwCOA3Knzp4.css" media="all" />
+
+    <!--[if (lt IE 9)&(!IEMobile)]>
+<link type="text/css" rel="stylesheet" href="https://www.pdga.com/files/css/css_bQWT4Y7gzc7H5zheA8kJK4pS5HSuyy4_KmtSxN0i7tg.css" media="all" />
+<![endif]-->
+
+    <!--[if gte IE 9]><!-->
+    <link type="text/css" rel="stylesheet"
+        href="https://www.pdga.com/files/css/css_Kq5qtRTePoqfww56uQINuctcU-wj2VJHL3l_w2DnIDw.css" media="all" />
+    <!--<![endif]-->
+    <script type="5093243ad95d540811482c94-text/javascript"
+        src="https://www.pdga.com/files/js/js_xiuPvf9G70dlGRfQaIGrQKOnFTg-JzRhgesZngs8Ap8.js"></script>
+    <script type="5093243ad95d540811482c94-text/javascript"
+        src="https://www.pdga.com/files/js/js_mOx0WHl6cNZI0fqrVldT0Ay6Zv7VRFDm9LexZoNN_NI.js"></script>
+    <script type="5093243ad95d540811482c94-text/javascript">
+<!--//-->
+    <![CDATA[//><!--
+jQuery.migrateMute=true;jQuery.migrateTrace=false;
+//--><!]]>
+    </script>
+    <script type="5093243ad95d540811482c94-text/javascript"
+        src="https://www.pdga.com/files/js/js_-Q9-jPbSLLTA4LDS2zwoqjnmRZX4zYgpycKVdCagsQQ.js"></script>
+    <script type="5093243ad95d540811482c94-text/javascript">
+<!--//-->
+    <![CDATA[//><!--
+var googletag = googletag || {};
+googletag.cmd = googletag.cmd || [];
+googletag.slots = googletag.slots || {};
+//--><!]]>
+    </script>
+    <script type="5093243ad95d540811482c94-text/javascript"
+        src="//securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+    <script type="5093243ad95d540811482c94-text/javascript"
+        src="https://www.pdga.com/files/js/js_Sg0OzNDUxCpXFlpCMn-v8c8PI6Rq9ULYCrMBTzc4Qxo.js"></script>
+    <script type="5093243ad95d540811482c94-text/javascript"
+        src="https://www.pdga.com/files/js/js_XjldFPE0I3jlq6JA5FHHiEEkjH4f0CwtCy0LR_KxeJM.js"></script>
+    <script type="5093243ad95d540811482c94-text/javascript">
+<!--//-->
+    <![CDATA[//><!--
+var mapping = googletag.sizeMapping()
+  .addSize([980, 690], [728, 90])
+  .addSize([640, 480], [468, 60])
+  .addSize([480, 240], [[468, 60], [320, 50]])
+  .addSize([0, 0], [[468, 60], [320, 50]])
+  .build();
+googletag.slots["schedule728"] = googletag.defineSlot("97231183/SCHEDULE728", [[728, 90], [468, 60], [320, 50], [243, 50]], "dfp-ad-schedule728")
+  .addService(googletag.pubads())
+  .set("adsense_ad_types", "image")
+  .defineSizeMapping(mapping);
+//--><!]]>
+    </script>
+    <script type="5093243ad95d540811482c94-text/javascript"
+        src="https://www.pdga.com/files/js/js_VI9kveObYV6KGZ0P5bY6jcNHGZ-GEaxSujIwlIbSB2s.js"></script>
+    <script type="5093243ad95d540811482c94-text/javascript"
+        src="https://www.pdga.com/files/js/js_rY7TXpfMLtmSC7MYaAuFjPu5omojqj3R2oM-nQtaibI.js"></script>
+    <script type="5093243ad95d540811482c94-text/javascript">
+<!--//-->
+    <![CDATA[//><!--
+googletag.cmd.push(function() {
+  googletag.pubads().enableAsyncRendering();
+  googletag.pubads().enableSingleRequest();
+  googletag.pubads().collapseEmptyDivs();
+  googletag.pubads().setTargeting("url", "tour/search");
+});
+
+googletag.enableServices();
+//--><!]]>
+    </script>
+    <script type="5093243ad95d540811482c94-text/javascript"
+        src="https://www.pdga.com/files/js/js_frkEq5CCdO1orLY_VKSELexXS0-1uFw1uE84xNkTsKg.js"></script>
+    <script type="5093243ad95d540811482c94-text/javascript"
+        src="https://www.pdga.com/files/googleanalytics/js?srie81"></script>
+    <script type="5093243ad95d540811482c94-text/javascript">
+<!--//-->
+    <![CDATA[//><!--
+window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments)};gtag("js", new Date());gtag("set", "developer_id.dMDhkMT", true);gtag("config", "UA-6108714-1", {"groups":"default"});
+//--><!]]>
+    </script>
+    <script type="5093243ad95d540811482c94-text/javascript"
+        src="https://www.pdga.com/files/js/js_by3ua4nz_aVMcjhLBRoaVYzWyNRHk--xaag33GaVWHA.js"></script>
+    <script type="5093243ad95d540811482c94-text/javascript"
+        src="https://www.pdga.com/files/js/js_ym7yBGpyoDQX0fTtvOxLMbqaotEHNddAfwWUJYRLVEw.js"></script>
+    <script type="5093243ad95d540811482c94-text/javascript"
+        src="https://www.pdga.com/files/js/js_43n5FBy8pZxQHxPXkf-sQF7ZiacVZke14b0VlvSA554.js"></script>
+    <script type="5093243ad95d540811482c94-text/javascript">
+<!--//-->
+    <![CDATA[//><!--
+jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","setHasJsCookie":0,"ajaxPageState":{"theme":"pdga","theme_token":"ysnxZJ5UwBNOkpd97AR6bd2O45t25cOJFsVxJPA9AVc","jquery_version":"1.12","jquery_version_token":"hzOzrRfFX7JpyPsmwX8kvkoTL4vk_Kha_BopYzzc4uM","js":{"0":1,"sites\/all\/modules\/contrib\/eu_cookie_compliance\/js\/eu_cookie_compliance.min.js":1,"https:\/\/www.pdga.com\/files\/google_tag\/www_pdga_com\/google_tag.script.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery\/1.12\/jquery.min.js":1,"1":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery-migrate\/1\/jquery-migrate.min.js":1,"misc\/jquery-extend-3.4.0.js":1,"misc\/jquery-html-prefilter-3.5.0-backport.js":1,"misc\/jquery.once.js":1,"2":1,"\/\/securepubads.g.doubleclick.net\/tag\/js\/gpt.js":1,"misc\/drupal.js":1,"sites\/all\/modules\/contrib\/jquery_update\/js\/jquery_browser.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.core.min.js":1,"sites\/all\/modules\/contrib\/nice_menus\/js\/jquery.bgiframe.js":1,"sites\/all\/modules\/contrib\/nice_menus\/js\/jquery.hoverIntent.js":1,"sites\/all\/modules\/contrib\/nice_menus\/js\/superfish.js":1,"sites\/all\/modules\/contrib\/nice_menus\/js\/nice_menus.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.datepicker.min.js":1,"misc\/ui\/jquery.ui.datepicker-1.13.0-backport.js":1,"sites\/all\/modules\/contrib\/date\/date_popup\/jquery.timeentry.pack.js":1,"sites\/all\/libraries\/history.js\/scripts\/bundled\/html4+html5\/jquery.history.js":1,"sites\/all\/modules\/contrib\/eu_cookie_compliance\/js\/jquery.cookie-1.4.1.min.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery.form\/4\/jquery.form.min.js":1,"3":1,"misc\/form-single-submit.js":1,"misc\/form.js":1,"misc\/ajax.js":1,"sites\/all\/modules\/contrib\/jquery_update\/js\/jquery_update.js":1,"sites\/all\/modules\/contrib\/comment_notify\/comment_notify.js":1,"sites\/all\/modules\/contrib\/entityreference\/js\/entityreference.js":1,"sites\/all\/modules\/custom\/pdga_maps\/js\/Control.FullScreen.js":1,"4":1,"sites\/all\/libraries\/colorbox\/jquery.colorbox-min.js":1,"sites\/all\/libraries\/DOMPurify\/purify.min.js":1,"sites\/all\/modules\/contrib\/colorbox\/js\/colorbox.js":1,"sites\/all\/modules\/contrib\/colorbox\/styles\/default\/colorbox_style.js":1,"sites\/all\/modules\/contrib\/colorbox\/js\/colorbox_inline.js":1,"sites\/all\/modules\/contrib\/better_exposed_filters\/better_exposed_filters.js":1,"sites\/all\/modules\/contrib\/date\/date_popup\/date_popup.js":1,"sites\/all\/modules\/features\/pdga_tournament\/pdga_tournament.js":1,"misc\/collapse.js":1,"sites\/all\/modules\/features\/pdga_system\/js\/formSingleSubmit.js":1,"sites\/all\/modules\/contrib\/views\/js\/base.js":1,"misc\/progress.js":1,"sites\/all\/modules\/contrib\/views\/js\/ajax_view.js":1,"sites\/all\/modules\/contrib\/google_analytics\/googleanalytics.js":1,"https:\/\/www.pdga.com\/files\/googleanalytics\/js?srie81":1,"5":1,"sites\/all\/modules\/contrib\/extlink\/js\/extlink.js":1,"sites\/all\/modules\/contrib\/views_ajax_history\/views_ajax_history.js":1,"sites\/all\/themes\/pdga\/js\/script.js":1,"sites\/all\/themes\/pdga\/js\/supposition.js":1,"sites\/all\/themes\/omega\/omega\/js\/jquery.formalize.js":1,"sites\/all\/themes\/omega\/omega\/js\/omega-mediaqueries.js":1},"css":{"modules\/system\/system.base.css":1,"modules\/system\/system.menus.css":1,"modules\/system\/system.messages.css":1,"modules\/system\/system.theme.css":1,"misc\/ui\/jquery.ui.core.css":1,"misc\/ui\/jquery.ui.theme.css":1,"misc\/ui\/jquery.ui.datepicker.css":1,"sites\/all\/modules\/contrib\/date\/date_popup\/themes\/jquery.timeentry.css":1,"sites\/all\/modules\/contrib\/comment_notify\/comment_notify.css":1,"modules\/book\/book.css":1,"modules\/comment\/comment.css":1,"modules\/field\/theme\/field.css":1,"sites\/all\/modules\/contrib\/logintoboggan\/logintoboggan.css":1,"modules\/node\/node.css":1,"sites\/all\/modules\/custom\/pdga_maps\/css\/Control.FullScreen.css":1,"sites\/all\/modules\/contrib\/quiz\/quiz.css":1,"modules\/user\/user.css":1,"sites\/all\/modules\/contrib\/extlink\/css\/extlink.css":1,"sites\/all\/modules\/contrib\/views\/css\/views.css":1,"sites\/all\/modules\/contrib\/ckeditor\/css\/ckeditor.css":1,"sites\/all\/modules\/features\/pdga_layout\/css\/layout.css":1,"sites\/all\/modules\/contrib\/colorbox\/styles\/default\/colorbox_style.css":1,"sites\/all\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/modules\/contrib\/nice_menus\/css\/nice_menus.css":1,"sites\/all\/modules\/contrib\/nice_menus\/css\/nice_menus_default.css":1,"sites\/all\/modules\/contrib\/date\/date_popup\/themes\/datepicker.1.7.css":1,"sites\/all\/modules\/contrib\/better_exposed_filters\/better_exposed_filters.css":1,"sites\/all\/modules\/custom\/tournament\/plugins\/content_types\/tournament_event_view.css":1,"sites\/all\/modules\/contrib\/panels\/plugins\/layouts\/onecol\/onecol.css":1,"sites\/all\/modules\/contrib\/eu_cookie_compliance\/css\/eu_cookie_compliance.css":1,"https:\/\/fonts.googleapis.com\/css2?family=Montserrat:wght@500;700\u0026display=swap":1,"https:\/\/fonts.googleapis.com\/css2?family=Source+Sans+3:ital,wght@0,500;1,500\u0026display=swap":1,"https:\/\/fonts.googleapis.com\/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@48,400,1,0":1,"https:\/\/fonts.googleapis.com\/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200":1,"sites\/all\/themes\/pdga\/css\/mm.css":1,"public:\/\/ctools\/css\/10aca8054def228cdb463d4dd3017872.css":1,"sites\/all\/themes\/omega\/alpha\/css\/alpha-mobile.css":1,"sites\/all\/themes\/omega\/alpha\/css\/alpha-alpha.css":1,"sites\/all\/themes\/pdga\/css\/omega-visuals.css":1,"sites\/all\/themes\/pdga\/css\/normalize.css":1,"sites\/all\/themes\/omega\/omega\/css\/formalize.css":1,"sites\/all\/themes\/omega\/omega\/css\/omega-text.css":1,"sites\/all\/themes\/omega\/omega\/css\/omega-branding.css":1,"sites\/all\/themes\/omega\/omega\/css\/omega-menu.css":1,"sites\/all\/themes\/omega\/omega\/css\/omega-forms.css":1,"sites\/all\/themes\/pdga\/css\/global.css":1,"ie::normal::sites\/all\/themes\/pdga\/css\/pdga-alpha-default.css":1,"ie::normal::sites\/all\/themes\/pdga\/css\/pdga-alpha-default-normal.css":1,"ie::normal::sites\/all\/themes\/omega\/alpha\/css\/grid\/alpha_default\/normal\/alpha-default-normal-16.css":1,"ie::normal::sites\/all\/themes\/omega\/alpha\/css\/grid\/alpha_default\/normal\/alpha-default-normal-12.css":1,"narrow::sites\/all\/themes\/pdga\/css\/pdga-alpha-default.css":1,"narrow::sites\/all\/themes\/pdga\/css\/pdga-alpha-default-narrow.css":1,"sites\/all\/themes\/omega\/alpha\/css\/grid\/alpha_default\/narrow\/alpha-default-narrow-16.css":1,"sites\/all\/themes\/omega\/alpha\/css\/grid\/alpha_default\/narrow\/alpha-default-narrow-12.css":1,"normal::sites\/all\/themes\/pdga\/css\/pdga-alpha-default.css":1,"normal::sites\/all\/themes\/pdga\/css\/pdga-alpha-default-normal.css":1,"sites\/all\/themes\/omega\/alpha\/css\/grid\/alpha_default\/normal\/alpha-default-normal-16.css":1,"sites\/all\/themes\/omega\/alpha\/css\/grid\/alpha_default\/normal\/alpha-default-normal-12.css":1}},"colorbox":{"opacity":"0.85","current":"{current} of {total}","previous":"\u00ab Prev","next":"Next \u00bb","close":"Close","maxWidth":"98%","maxHeight":"98%","fixed":true,"mobiledetect":false,"mobiledevicewidth":"480px","file_public_path":"\/files","specificPagesDefaultValue":"admin*\nimagebrowser*\nimg_assist*\nimce*\nnode\/add\/*\nnode\/*\/edit\nprint\/*\nprintpdf\/*\nsystem\/ajax\nsystem\/ajax\/*"},"nice_menus_options":{"delay":"800","speed":"fast"},"better_exposed_filters":{"datepicker":false,"slider":false,"settings":[],"autosubmit":false,"views":{"pdga_tournament_list":{"displays":{"panel_pane_1":{"filters":{"OfficialName":{"required":false},"td":{"required":false},"Country":{"required":false},"Continent":{"required":false},"State":{"required":false},"State_1":{"required":false},"Tier":{"required":false},"Classification":{"required":false},"date_filter":{"required":false},"UpdateDate":{"required":false},"TournID":{"required":false},"EventType":{"required":false}}}}}}},"datePopup":{"edit-date-filter-min-datepicker-popup-0":{"func":"datepicker","settings":{"changeMonth":true,"changeYear":true,"autoPopUp":"focus","closeAtTop":false,"speed":"immediate","firstDay":0,"dateFormat":"yy-mm-dd","yearRange":"-51:+1","fromTo":false,"defaultDate":"0y"}},"edit-date-filter-max-datepicker-popup-0":{"func":"datepicker","settings":{"changeMonth":true,"changeYear":true,"autoPopUp":"focus","closeAtTop":false,"speed":"immediate","firstDay":0,"dateFormat":"yy-mm-dd","yearRange":"-51:+1","fromTo":false,"defaultDate":"0y"}},"edit-date-filter-min-datepicker-popup-1":{"func":"datepicker","settings":{"changeMonth":true,"changeYear":true,"autoPopUp":"focus","closeAtTop":false,"speed":"immediate","firstDay":0,"dateFormat":"yy-mm-dd","yearRange":"-51:+1","fromTo":false,"defaultDate":"0y"}},"edit-date-filter-max-datepicker-popup-1":{"func":"datepicker","settings":{"changeMonth":true,"changeYear":true,"autoPopUp":"focus","closeAtTop":false,"speed":"immediate","firstDay":0,"dateFormat":"yy-mm-dd","yearRange":"-51:+1","fromTo":false,"defaultDate":"0y"}}},"urlIsAjaxTrusted":{"\/tour\/search":true,"\/views\/ajax":true},"viewsAjaxHistory":{"renderPageItem":"1"},"views":{"ajax_path":"\/views\/ajax","ajaxViews":{"views_dom_id:bd0da36c15864d2a05d7f05b0b6adb7a":{"view_name":"pdga_tournament_list","view_display_id":"panel_pane_1","view_args":"","view_path":"tour\/search","view_base_path":null,"view_dom_id":"bd0da36c15864d2a05d7f05b0b6adb7a","pager_element":0}}},"eu_cookie_compliance":{"cookie_policy_version":"1.0.1","popup_enabled":1,"popup_agreed_enabled":0,"popup_hide_agreed":0,"popup_clicking_confirmation":false,"popup_scrolling_confirmation":false,"popup_html_info":"\u003Cdiv class=\u0022eu-cookie-compliance-banner eu-cookie-compliance-banner-info eu-cookie-compliance-banner--opt-in\u0022\u003E\n  \u003Cdiv class=\u0022popup-content info\u0022\u003E\n        \u003Cdiv id=\u0022popup-text\u0022\u003E\n      \u003Cp\u003EWe use cookies on this site to deliver a better experience to you. By agreeing, you give us your consent to do so.\u003C\/p\u003E\n              \u003Cbutton type=\u0022button\u0022 class=\u0022find-more-button eu-cookie-compliance-more-button\u0022\u003EView our privacy policy for details. \u003C\/button\u003E\n          \u003C\/div\u003E\n    \n    \u003Cdiv id=\u0022popup-buttons\u0022 class=\u0022\u0022\u003E\n            \u003Cbutton type=\u0022button\u0022 class=\u0022agree-button eu-cookie-compliance-secondary-button\u0022\u003EOK, I agree\u003C\/button\u003E\n              \u003Cbutton type=\u0022button\u0022 class=\u0022decline-button eu-cookie-compliance-default-button\u0022 \u003ENo, thanks\u003C\/button\u003E\n          \u003C\/div\u003E\n  \u003C\/div\u003E\n\u003C\/div\u003E","use_mobile_message":false,"mobile_popup_html_info":"\u003Cdiv class=\u0022eu-cookie-compliance-banner eu-cookie-compliance-banner-info eu-cookie-compliance-banner--opt-in\u0022\u003E\n  \u003Cdiv class=\u0022popup-content info\u0022\u003E\n        \u003Cdiv id=\u0022popup-text\u0022\u003E\n      \u003Ch2\u003EWe use cookies on this site to enhance your user experience\u003C\/h2\u003E\n\u003Cp\u003EBy tapping the Accept button, you agree to us doing so.\u003C\/p\u003E\n              \u003Cbutton type=\u0022button\u0022 class=\u0022find-more-button eu-cookie-compliance-more-button\u0022\u003EView our privacy policy for details. \u003C\/button\u003E\n          \u003C\/div\u003E\n    \n    \u003Cdiv id=\u0022popup-buttons\u0022 class=\u0022\u0022\u003E\n            \u003Cbutton type=\u0022button\u0022 class=\u0022agree-button eu-cookie-compliance-secondary-button\u0022\u003EOK, I agree\u003C\/button\u003E\n              \u003Cbutton type=\u0022button\u0022 class=\u0022decline-button eu-cookie-compliance-default-button\u0022 \u003ENo, thanks\u003C\/button\u003E\n          \u003C\/div\u003E\n  \u003C\/div\u003E\n\u003C\/div\u003E\n","mobile_breakpoint":"768","popup_html_agreed":"\u003Cdiv\u003E\n  \u003Cdiv class=\u0022popup-content agreed\u0022\u003E\n    \u003Cdiv id=\u0022popup-text\u0022\u003E\n      \u003Cp\u003E\u0026lt;h2\u0026gt;Thank you for accepting cookies\u0026lt;\/h2\u0026gt;\u0026lt;p\u0026gt;You can now hide this message or find out more about cookies.\u0026lt;\/p\u0026gt;\u003C\/p\u003E\n    \u003C\/div\u003E\n    \u003Cdiv id=\u0022popup-buttons\u0022\u003E\n      \u003Cbutton type=\u0022button\u0022 class=\u0022hide-popup-button eu-cookie-compliance-hide-button\u0022\u003EHide\u003C\/button\u003E\n              \u003Cbutton type=\u0022button\u0022 class=\u0022find-more-button eu-cookie-compliance-more-button-thank-you\u0022 \u003EMore info\u003C\/button\u003E\n          \u003C\/div\u003E\n  \u003C\/div\u003E\n\u003C\/div\u003E","popup_use_bare_css":false,"popup_height":"auto","popup_width":"100%","popup_delay":1000,"popup_link":"\/privacy","popup_link_new_window":0,"popup_position":null,"fixed_top_position":1,"popup_language":"en","store_consent":true,"better_support_for_screen_readers":0,"reload_page":0,"domain":"","domain_all_sites":0,"popup_eu_only_js":0,"cookie_lifetime":"365","cookie_session":false,"disagree_do_not_show_popup":0,"method":"opt_in","allowed_cookies":"","withdraw_markup":"\u003Cbutton type=\u0022button\u0022 class=\u0022eu-cookie-withdraw-tab\u0022\u003ECookie settings\u003C\/button\u003E\n\u003Cdiv class=\u0022eu-cookie-withdraw-banner\u0022\u003E\n  \u003Cdiv class=\u0022popup-content info\u0022\u003E\n    \u003Cdiv id=\u0022popup-text\u0022\u003E\n      \u003Cp\u003EWe use cookies on this site to deliver a better experience to you.\u00a0You have given your consent for us to set cookies.\u003C\/p\u003E\n    \u003C\/div\u003E\n    \u003Cdiv id=\u0022popup-buttons\u0022\u003E\n      \u003Cbutton type=\u0022button\u0022 class=\u0022eu-cookie-withdraw-button\u0022\u003EWithdraw consent\u003C\/button\u003E\n    \u003C\/div\u003E\n  \u003C\/div\u003E\n\u003C\/div\u003E\n","withdraw_enabled":false,"withdraw_button_on_info_popup":0,"cookie_categories":[],"cookie_categories_details":[],"enable_save_preferences_button":1,"cookie_name":"","cookie_value_disagreed":"0","cookie_value_agreed_show_thank_you":"1","cookie_value_agreed":"2","containing_element":"body","automatic_cookies_removal":1,"close_button_action":"close_banner"},"googleanalytics":{"account":["UA-6108714-1"],"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc(x|m)?|dot(x|m)?|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt(x|m)?|pot(x|m)?|pps(x|m)?|ppam|sld(x|m)?|thmx|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls(x|m|b)?|xlt(x|m)|xlam|xml|z|zip","trackColorbox":1},"extlink":{"extTarget":"_blank","extClass":0,"extLabel":"(link is external)","extImgClass":0,"extIconPlacement":0,"extSubdomains":0,"extExclude":"course\\\/add.","extInclude":"tour\\\/live.","extCssExclude":".api-pdga-com","extCssExplicit":"","extAlert":0,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":0,"mailtoLabel":"(link sends e-mail)","extUseFontAwesome":0},"omega":{"layouts":{"primary":"normal","order":["narrow","normal"],"queries":{"narrow":"all and (min-width: 740px) and (min-device-width: 740px), (max-device-width: 800px) and (min-width: 740px) and (orientation:landscape)","normal":"all and (min-width: 980px) and (min-device-width: 980px), all and (max-device-width: 1024px) and (min-width: 1024px) and (orientation:landscape)"}}}});
+//--><!]]>
+    </script>
+</head>
+
+<body class="html not-front not-logged-in page-tour page-tour-search panel-custom-title context-tour">
+    <div id="skip-link">
+        <a href="#main-content" class="element-invisible element-focusable">Skip to main content</a>
+    </div>
+    <div class="region region-page-top" id="region-page-top">
+        <div class="region-inner region-page-top-inner">
+            <noscript aria-hidden="true"><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NGS4KXL"
+                    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+        </div>
+    </div>
+    <div class="page clearfix" id="page">
+        <header id="section-header" class="section section-header">
+            <div id="zone-branding-wrapper" class="zone-wrapper zone-branding-wrapper clearfix">
+                <div id="zone-branding" class="zone zone-branding clearfix container-16">
+                    <div class="grid-11 region region-branding" id="region-branding">
+                        <div class="region-inner region-branding-inner">
+                            <div class="branding-data clearfix">
+                                <div class="logo-img">
+                                    <a href="/" rel="home" title=""><img
+                                            src="https://www.pdga.com/sites/all/themes/pdga/logo.png" alt=""
+                                            id="logo" /></a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="grid-5 region region-user-bar" id="region-user-bar">
+                        <div class="region-inner region-user-bar-inner">
+                            <div class="block block-panels-mini block-header-user-bar block-panels-mini-header-user-bar odd block-without-title"
+                                id="block-panels-mini-header-user-bar">
+                                <div class="block-inner clearfix">
+
+                                    <div class="content clearfix">
+                                        <div class="panel-display panel-1col clearfix" id="mini-panel-header_user_bar">
+                                            <div class="panel-panel panel-col">
+                                                <div>
+                                                    <div class="panel-pane pane-custom pane-1 pane-social-links inline clearfix"
+                                                        class="panel-pane pane-custom pane-1 pane-social-links inline clearfix">
+
+
+
+                                                        <div class="pane-content">
+                                                            <ul class="menu social-links">
+                                                                <!-- li><a class="rss" href="/frontpage/feed" target="_blank" title="Subscribe to the PDGA RSS Feed">RSS Feed</a></li -->
+                                                                <li><a class="twitter" href="https://twitter.com/pdga"
+                                                                        target="_blank"
+                                                                        title="PDGA on Twitter">Twitter</a></li>
+                                                                <li><a class="instagram"
+                                                                        href="https://instagram.com/pdga"
+                                                                        target="_blank"
+                                                                        title="PDGA on Instagram">Instagram</a></li>
+                                                                <li><a class="facebook"
+                                                                        href="https://www.facebook.com/pdga"
+                                                                        target="_blank"
+                                                                        title="PDGA on Facebook">Facebook</a></li>
+                                                                <li><a class="flickr"
+                                                                        href="https://www.flickr.com/photos/pdga/"
+                                                                        target="_blank"
+                                                                        title="PDGA on Flickr">Flickr</a></li>
+                                                                <li><a class="youtube"
+                                                                        href="https://www.youtube.com/user/pdgamedia"
+                                                                        target="_blank"
+                                                                        title="PDGA on YouTube">YouTube</a></li>
+                                                                <li><a class="linkedin"
+                                                                        href="https://www.linkedin.com/groups?gid=31030"
+                                                                        target="_blank"
+                                                                        title="PDGA on LinkedIn">LinkedIn</a></li>
+                                                            </ul>
+                                                        </div>
+
+
+                                                    </div>
+                                                    <div class="panel-separator"></div>
+                                                    <div class="panel-pane pane-pdga-search-searchapi-block pane-search-form"
+                                                        class="panel-pane pane-pdga-search-searchapi-block pane-search-form">
+
+                                                        <h2 class="pane-title">
+                                                            Search </h2>
+
+
+                                                        <div class="pane-content">
+
+                                                            <div class="container-inline">
+                                                                <form class="search-form" action="/search" method="get"
+                                                                    id="search-form" accept-charset="UTF-8">
+                                                                    <div>
+                                                                        <div
+                                                                            class="form-item form-type-textfield form-item-keywords">
+                                                                            <input type="text" name="keywords"
+                                                                                autocorrect="off" value="" size="15"
+                                                                                maxlength="128" class="form-text">
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="form-actions">
+                                                                        <input type="submit" value="Search"
+                                                                            class="form-submit">
+                                                                    </div>
+                                                                </form>
+                                                            </div>
+                                                        </div>
+
+
+                                                    </div>
+                                                    <div class="panel-separator"></div>
+                                                    <div class="panel-pane pane-block pane-system-user-menu inline"
+                                                        class="panel-pane pane-block pane-system-user-menu inline">
+
+
+
+                                                        <div class="pane-content">
+                                                            <ul class="menu">
+                                                                <li class="first leaf"><a
+                                                                        href="/user/login?destination=tour/search%3Fdate_filter%255Bmin%255D%255Bdate%255D%3D2023-02-01%26State%255B0%255D%3DPA%26Tier%255B0%255D%3DA%26Tier%255B1%255D%3DB%26Tier%255B2%255D%3DC%26page%3D1"
+                                                                        title="">Login</a></li>
+                                                                <li class="leaf"><a href="/membership" title="">Join
+                                                                        &amp; Renew</a></li>
+                                                                <li class="last leaf"><a href="/contact"
+                                                                        title="">Contact</a></li>
+                                                            </ul>
+                                                        </div>
+
+
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div id="zone-menu-wrapper" class="zone-wrapper zone-menu-wrapper clearfix">
+                <div id="zone-menu" class="zone zone-menu clearfix container-12">
+                    <div class="grid-12 region region-menu" id="region-menu">
+                        <div class="region-inner region-menu-inner">
+                            <section class="block block-nice-menus block-1 block-nice-menus-1 odd"
+                                id="block-nice-menus-1">
+                                <div class="block-inner clearfix">
+                                    <h2 class="block-title">Main Menu</h2>
+
+                                    <div class="content clearfix">
+                                        <ul class="nice-menu nice-menu-down nice-menu-main-menu" id="nice-menu-1">
+                                            <li class="menu-5628 menu-path-front first odd "><a href="/">Home</a></li>
+                                            <li class="menu-5629 menuparent  menu-path-nolink  even ">
+                                                <div title="" class="nolink" tabindex="0">About</div>
+                                                <ul>
+                                                    <li class="menu-5637 menu-path-node-21340 first odd "><a
+                                                            href="/introduction">What is Disc Golf?</a></li>
+                                                    <li class="menu-5638 menu-path-node-21339  even "><a
+                                                            href="/history">History</a></li>
+                                                    <li class="menu-54196 menu-path-node-286386  odd "><a
+                                                            href="/board-directors">Board of Directors</a></li>
+                                                    <li class="menu-219411 menu-path-node-273186  even "><a
+                                                            href="/leadership">Leadership</a></li>
+                                                    <li class="menu-68566 menuparent  menu-path-node-215136  odd "><a
+                                                            href="/volunteers">Volunteers</a>
+                                                        <ul>
+                                                            <li class="menu-68571 menu-path-node-214916 first odd "><a
+                                                                    href="/volunteers/state-coordinators">State
+                                                                    Coordinators</a></li>
+                                                            <li class="menu-68576 menu-path-node-214921  even "><a
+                                                                    href="/volunteers/province-coordinators">Province
+                                                                    Coordinators</a></li>
+                                                            <li class="menu-68581 menu-path-node-214926  odd "><a
+                                                                    href="/volunteers/country-representatives">Country
+                                                                    Representatives</a></li>
+                                                            <li
+                                                                class="menu-82411 menu-path-node-215136-committees  even last">
+                                                                <a href="/volunteers/committees" title="">Committees</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="menu-7824 menu-path-node-200525  even "><a
+                                                            href="/news">News</a></li>
+                                                    <li class="menu-68541 menu-path-announcements  odd "><a
+                                                            href="/announcements" title="">Announcements</a></li>
+                                                    <li class="menu-5639 menu-path-faq-page  even "><a href="/faq-page"
+                                                            title="">FAQs</a></li>
+                                                    <li class="menu-223926 menu-path-node-305583  odd last"><a
+                                                            href="/careers">Careers @ the PDGA</a></li>
+                                                </ul>
+                                            </li>
+                                            <li class="menu-5630 menuparent  menu-path-nolink  odd ">
+                                                <div title="" class="nolink" tabindex="0">Membership</div>
+                                                <ul>
+                                                    <li class="menu-18326 menu-path-membership first odd "><a
+                                                            href="/membership" title="">Join &amp; Renew</a></li>
+                                                    <li class="menu-19956 menu-path-node-21323  even "><a
+                                                            href="/members/benefits">Member Benefits</a></li>
+                                                    <li class="menu-5715 menu-path-node-21325  odd "><a
+                                                            href="/clubs">PDGA Clubs</a></li>
+                                                    <li class="menu-5641 menu-path-players  even "><a
+                                                            href="/players">Player Search</a></li>
+                                                    <li class="menu-5642 menu-path-players-stats  odd "><a
+                                                            href="/players/stats" title="">Player Statistics</a></li>
+                                                    <li class="menu-5643 menu-path-node-304033  even "><a
+                                                            href="/world-rankings">Official Disc Golf World Rankings</a>
+                                                    </li>
+                                                    <li class="menu-222620 menu-path-node-294946  odd "><a
+                                                            href="/global-masters-series">Global Masters Series</a></li>
+                                                    <li class="menu-68531 menu-path-node-291176  even "><a
+                                                            href="/awards-and-achievements">Awards and Achievements</a>
+                                                    </li>
+                                                    <li class="menu-5676 menu-path-node-28442  odd "><a
+                                                            href="/divisions">Beginner&#039;s Guide to PDGA
+                                                            Divisions</a></li>
+                                                    <li class="menu-5646 menu-path-node-21372  even "><a
+                                                            href="/seniors">Seniors</a></li>
+                                                    <li class="menu-5644 menu-path-node-21364  odd "><a
+                                                            href="/women">Women</a></li>
+                                                    <li class="menu-5645 menu-path-node-273661  even last"><a
+                                                            href="/youth-and-education">Youth &amp; Education</a></li>
+                                                </ul>
+                                            </li>
+                                            <li class="menu-5631 menuparent  menu-path-nolink active-trail  even ">
+                                                <div title="" class="nolink" tabindex="0">Events</div>
+                                                <ul>
+                                                    <li class="menu-5647 menu-path-tour-events first odd "><a
+                                                            href="/tour/events">Event Schedule &amp; Results</a></li>
+                                                    <li class="menu-146101 menu-path-tour-events-upcoming  even "><a
+                                                            href="/tour/events/upcoming" title="">Upcoming Events
+                                                            Map</a></li>
+                                                    <li class="menu-5648 menu-path-tour-search active-trail  odd "><a
+                                                            href="/tour/search" class="active">Event Search</a></li>
+                                                    <li class="menu-104111 menu-path-node-266741  even "><a
+                                                            href="/elite-series">Elite Series</a></li>
+                                                    <li class="menu-5649 menu-path-node-21370  odd "><a
+                                                            href="/major-disc-golf-events">Major Disc Golf Events</a>
+                                                    </li>
+                                                    <li class="menu-5650 menu-path-node-21355  even "><a
+                                                            href="/worlds">World Championships</a></li>
+                                                    <li class="menu-5651 menuparent  menu-path-node-21391  odd "><a
+                                                            href="/leagues">PDGA Leagues</a>
+                                                        <ul>
+                                                            <li class="menu-9165 menu-path-leagues-events first odd "><a
+                                                                    href="/leagues/events" title="">League Schedule</a>
+                                                            </li>
+                                                            <li class="menu-119371 menu-path-node-28432  even last"><a
+                                                                    href="/pdga-event-sanctioning-agreement"
+                                                                    title="">League Sanctioning</a></li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="menu-199586 menu-path-node-21398  even "><a
+                                                            href="/women/global-event" title="">Women&#039;s Global
+                                                            Event</a></li>
+                                                    <li class="menu-5652 menuparent  menu-path-node-21342  odd last"><a
+                                                            href="/td">Tournament Directors</a>
+                                                        <ul>
+                                                            <li class="menu-68121 menu-path-node-21419 first odd "><a
+                                                                    href="/td/event-planning-management">Event Planning
+                                                                    &amp; Management</a></li>
+                                                            <li class="menu-7811 menu-path-node-28432  even "><a
+                                                                    href="/pdga-event-sanctioning-agreement">Event
+                                                                    Sanctioning</a></li>
+                                                            <li class="menu-7812 menu-path-node-30232  odd last"><a
+                                                                    href="/event-payments">Event Payments</a></li>
+                                                        </ul>
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                            <li class="menu-5632 menuparent  menu-path-nolink  odd ">
+                                                <div title="" class="nolink" tabindex="0">Courses</div>
+                                                <ul>
+                                                    <li class="menu-5655 menu-path-course-directory first odd "><a
+                                                            href="/course-directory">Course Directory Map</a></li>
+                                                    <li class="menu-7059 menu-path-course-directory-advanced  even "><a
+                                                            href="/course-directory/advanced" title="">Course Search</a>
+                                                    </li>
+                                                    <li class="menu-14056 menu-path-node-274691  odd "><a
+                                                            href="/course/add" title="">Add New Course</a></li>
+                                                    <li class="menu-5656 menu-path-node-21324  even last"><a
+                                                            href="/course-development">Course Development</a></li>
+                                                </ul>
+                                            </li>
+                                            <li class="menu-5668 menuparent  menu-path-nolink  even ">
+                                                <div title="" class="nolink" tabindex="0">Rules</div>
+                                                <ul>
+                                                    <li class="menu-9157 menu-path-node-8371 first odd "><a
+                                                            href="/rules" title="">Overview</a></li>
+                                                    <li class="menu-5657 menu-path-node-236656  even "><a
+                                                            href="/rules/official-rules-disc-golf">Official Rules of
+                                                            Disc Golf</a></li>
+                                                    <li class="menu-6102 menu-path-node-236661  odd "><a
+                                                            href="/rules/competition-manual-disc-golf-events">Competition
+                                                            Manual for Disc Golf Events</a></li>
+                                                    <li class="menu-104211 menu-path-taxonomy-term-780  even "><a
+                                                            href="/pdga-documents/international-rules"
+                                                            title="">Translated Rules of Disc Golf</a></li>
+                                                    <li class="menu-6103 menu-path-node-23201  odd "><a
+                                                            href="/pdga-documents/tour-documents/divisions-ratings-and-points-factors">Divisions,
+                                                            Ratings and Points Factors</a></li>
+                                                    <li class="menu-73106 menuparent  menu-path-node-23211  even "><a
+                                                            href="/tour-standards">Tour Standards</a>
+                                                        <ul>
+                                                            <li class="menu-222691 menu-path-node-23211 first odd "><a
+                                                                    href="/tour-standards" title="">United States/Canada
+                                                                    Tour Standards</a></li>
+                                                            <li class="menu-222690 menu-path-node-303282  even last"><a
+                                                                    href="/pdga-documents/tour-documents/pdga-international-tour-standards">International
+                                                                    Tour Standards</a></li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="menu-5721 menuparent  menu-path-node-21335  odd "><a
+                                                            href="/technical-standards">Technical Standards</a>
+                                                        <ul>
+                                                            <li
+                                                                class="menu-197326 menu-path-technical-standards-equipment-certification-discs first odd ">
+                                                                <a href="/technical-standards/equipment-certification/discs"
+                                                                    title="">Approved Discs</a></li>
+                                                            <li
+                                                                class="menu-197331 menu-path-technical-standards-equipment-certification-targets  even last">
+                                                                <a href="/technical-standards/equipment-certification/targets"
+                                                                    title="">Approved Targets</a></li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="menu-70411 menu-path-node-216411  even "><a
+                                                            href="/code">Disc Golfer&#039;s Code</a></li>
+                                                    <li class="menu-5658 menu-path-rules-exam  odd last"><a
+                                                            href="/rules/exam" title="">Certified Rules Official
+                                                            Exam</a></li>
+                                                </ul>
+                                            </li>
+                                            <li class="menu-5634 menuparent  menu-path-nolink  odd ">
+                                                <div title="" class="nolink" tabindex="0">Media</div>
+                                                <ul>
+                                                    <li class="menu-17226 menu-path-node-200525 first odd "><a
+                                                            href="/news" title="">News</a></li>
+                                                    <li class="menu-68551 menu-path-announcements  even "><a
+                                                            href="/announcements" title="">Announcements</a></li>
+                                                    <li class="menu-5659 menu-path-node-21353  odd "><a
+                                                            href="/discgolfer-magazine">DiscGolfer Magazine</a></li>
+                                                    <li class="menu-68256 menu-path-radio  even "><a href="/radio"
+                                                            title="">PDGA Radio</a></li>
+                                                    <li class="menu-5661 menu-path-videos  odd "><a
+                                                            href="/videos">Videos</a></li>
+                                                    <li class="menu-17236 menuparent  menu-path-nolink  even ">
+                                                        <div title="" class="nolink" tabindex="0">Photos</div>
+                                                        <ul>
+                                                            <li
+                                                                class="menu-5660 menu-path-sflickrcom-photos-pdga- first odd ">
+                                                                <a href="https://www.flickr.com/photos/pdga/"
+                                                                    title="">Flickr</a></li>
+                                                            <li
+                                                                class="menu-17241 menu-path-instagramcom-pdga  even last">
+                                                                <a href="https://www.instagram.com/pdga"
+                                                                    title="">Instagram</a></li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="menu-17246 menuparent  menu-path-nolink  odd ">
+                                                        <div title="" class="nolink" tabindex="0">Social Media</div>
+                                                        <ul>
+                                                            <li class="menu-5662 menu-path-facebookcom-pdga first odd ">
+                                                                <a href="https://www.facebook.com/pdga">Facebook</a>
+                                                            </li>
+                                                            <li class="menu-5663 menu-path-twittercom-pdga  even "><a
+                                                                    href="https://twitter.com/pdga">Twitter</a></li>
+                                                            <li
+                                                                class="menu-17251 menu-path-slinkedincom-groupsgid31030  odd last">
+                                                                <a href="https://www.linkedin.com/groups?gid=31030"
+                                                                    title="">LinkedIn</a></li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="menu-119501 menu-path-taxonomy-term-6441  even "><a
+                                                            href="/press-releases" title="">Press Releases</a></li>
+                                                    <li class="menu-17231 menu-path-node-202681  odd last"><a
+                                                            href="/media">Share Your Stories, Videos &amp; Photos!</a>
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                            <li class="menu-5635 menuparent  menu-path-node-21338  even "><a
+                                                    href="/international">International</a>
+                                                <ul>
+                                                    <li class="menu-104186 menuparent  menu-path-node-21338 first odd ">
+                                                        <a href="/international" title="">PDGA International</a>
+                                                        <ul>
+                                                            <li
+                                                                class="menu-222689 menu-path-node-286121 first odd last">
+                                                                <a href="/international/international-program-guide">International
+                                                                    Program Guide</a></li>
+                                                        </ul>
+                                                    </li>
+                                                    <li class="menu-104201 menu-path-node-265701  even "><a
+                                                            href="/europe">PDGA Europe</a></li>
+                                                    <li class="menu-104196 menu-path-node-229751  odd "><a
+                                                            href="/canada">PDGA Canada</a></li>
+                                                    <li class="menu-104191 menu-path-node-21403  even last"><a
+                                                            href="/marco-polo-program">Marco Polo Program</a></li>
+                                                </ul>
+                                            </li>
+                                            <li class="menu-5636 menuparent  menu-path-nolink  odd last">
+                                                <div title="" class="nolink" tabindex="0">More</div>
+                                                <ul>
+                                                    <li class="menu-5664 menu-path-node-289751 first odd "><a
+                                                            href="/advertise-pdga" title="">Advertising</a></li>
+                                                    <li class="menu-5719 menu-path-node-21344  even "><a
+                                                            href="/pdga-association-documents">Association Documents</a>
+                                                    </li>
+                                                    <li class="menu-5716 menu-path-contact  odd "><a href="/contact"
+                                                            title="">Contact</a></li>
+                                                    <li class="menu-5717 menu-path-node-21352  even "><a
+                                                            href="/demographics">Demographics</a></li>
+                                                    <li class="menu-82441 menu-path-sdiscgolffoundationorg  odd "><a
+                                                            href="https://www.discgolffoundation.org" title="">Disc Golf
+                                                            Foundation</a></li>
+                                                    <li class="menu-55776 menu-path-node-207796  even "><a
+                                                            href="/DGHOF">Disc Golf Hall of Fame</a></li>
+                                                    <li class="menu-5718 menu-path-node-21354  odd "><a
+                                                            href="/pdga-disciplinary-process">Disciplinary Process</a>
+                                                    </li>
+                                                    <li class="menu-5666 menu-path-node-21357  even "><a
+                                                            href="/elections">Elections</a></li>
+                                                    <li class="menu-5665 menu-path-node-30227  odd "><a
+                                                            href="/IDGC">International Disc Golf Center</a></li>
+                                                    <li class="menu-14021 menu-path-smailchimp-pdga-subscribe  even "><a
+                                                            href="https://mailchi.mp/pdga/subscribe" title="">PDGA
+                                                            Weekly Newsletter</a></li>
+                                                    <li class="menu-5720 menu-path-node-28438  odd "><a
+                                                            href="/points">Points</a></li>
+                                                    <li class="menu-5667 menu-path-node-21356  even "><a
+                                                            href="/ratings">Ratings</a></li>
+                                                    <li class="menu-223575 menu-path-node-303709  odd "><a
+                                                            href="/throwgreen">Throw Green</a></li>
+                                                    <li class="menu-222693 menu-path-swfdfsport  even "><a
+                                                            href="https://wfdf.sport" title="">WFDF</a></li>
+                                                    <li class="menu-7795 menu-path-taxonomy-term-743  odd last"><a
+                                                            href="/pdga-documents" title="">Recently Updated
+                                                            Documents</a></li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </section>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div id="zone-header-wrapper" class="zone-wrapper zone-header-wrapper clearfix">
+                <div id="zone-header" class="zone zone-header clearfix container-12">
+                    <div class="grid-12 region region-header top-banner" id="region-header">
+                        <div class="region-inner region-header-inner">
+                            <div class="block block-dfp block-schedule728 block-dfp-schedule728 odd block-without-title"
+                                id="block-dfp-schedule728">
+                                <div class="block-inner clearfix">
+
+                                    <div class="content clearfix">
+                                        <div id="dfp-ad-schedule728-wrapper" class="dfp-tag-wrapper">
+                                            <div id="dfp-ad-schedule728" class="dfp-tag-wrapper">
+                                                <script type="5093243ad95d540811482c94-text/javascript">
+    googletag.cmd.push(function() {
+      googletag.display("dfp-ad-schedule728");
+    });
+  </script>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </header>
+        <section id="section-content" class="section section-content">
+            <div id="zone-content-wrapper" class="zone-wrapper zone-content-wrapper clearfix">
+                <div id="zone-content" class="zone zone-content clearfix container-16">
+
+                    <div class="grid-16 region region-content" id="region-content">
+                        <div class="region-inner region-content-inner">
+                            <a id="main-content"></a>
+                            <h1 class="title" id="page-title">Disc Golf Event Search</h1>
+                            <div class="block block-system block-main block-system-main odd block-without-title"
+                                id="block-system-main">
+                                <div class="block-inner clearfix">
+
+                                    <div class="content clearfix">
+                                        <div class="panel-display omega-grid pdga-one-col clearfix">
+
+                                            <div class="panel-panel grid-16">
+                                                <div class="inside">
+                                                    <div class="panel-pane pane-page-title"
+                                                        class="panel-pane pane-page-title">
+
+
+
+                                                        <div class="pane-content">
+                                                            <h1>Disc Golf Event Search</h1>
+                                                        </div>
+
+
+                                                    </div>
+                                                    <div class="panel-separator"></div>
+                                                    <div class="panel-pane pane-block pane-menu-menu-event-schedule"
+                                                        class="panel-pane pane-block pane-menu-menu-event-schedule">
+
+
+
+                                                        <div class="pane-content">
+                                                            <ul class="menu">
+                                                                <li class="first leaf"><a href="/tour/events"
+                                                                        title="">Tournament Schedule</a></li>
+                                                                <li class="leaf"><a href="/leagues/events"
+                                                                        title="">League Schedule</a></li>
+                                                                <li class="leaf"><a href="/tour/events/upcoming"
+                                                                        title="">Upcoming Events Map</a></li>
+                                                                <li class="last leaf active-trail"><a
+                                                                        href="/tour/search" title=""
+                                                                        class="active-trail active">Advanced Event
+                                                                        Search</a></li>
+                                                            </ul>
+                                                        </div>
+
+
+                                                    </div>
+                                                    <div class="panel-separator"></div>
+                                                    <div class="panel-pane pane-block pane-views-f3c13a2b99750bfdb5f9f5c9a97af4d7"
+                                                        class="panel-pane pane-block pane-views-f3c13a2b99750bfdb5f9f5c9a97af4d7">
+
+
+
+                                                        <div class="pane-content">
+                                                            <form action="/tour/search" method="get"
+                                                                id="views-exposed-form-pdga-tournament-list-panel-pane-1"
+                                                                accept-charset="UTF-8">
+                                                                <div>
+                                                                    <div class="views-exposed-form">
+                                                                        <div class="views-exposed-widgets clearfix">
+                                                                            <div id="edit-officialname-wrapper"
+                                                                                class="views-exposed-widget views-widget-filter-OfficialName">
+                                                                                <label for="edit-officialname">
+                                                                                    Event Name </label>
+                                                                                <div class="views-widget">
+                                                                                    <div
+                                                                                        class="form-item form-type-textfield form-item-OfficialName">
+                                                                                        <input type="text"
+                                                                                            id="edit-officialname"
+                                                                                            name="OfficialName" value=""
+                                                                                            size="30" maxlength="128"
+                                                                                            class="form-text" />
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                            <div id="edit-td-wrapper"
+                                                                                class="views-exposed-widget views-widget-filter-combine">
+                                                                                <label for="edit-td">
+                                                                                    Event Director PDGA # </label>
+                                                                                <div class="views-widget">
+                                                                                    <div
+                                                                                        class="form-item form-type-textfield form-item-td">
+                                                                                        <input type="text" id="edit-td"
+                                                                                            name="td" value="" size="30"
+                                                                                            maxlength="128"
+                                                                                            class="form-text" />
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                            <div id="date_views_exposed_filter-1efdc59efb31841d044036174ce6b00e-wrapper"
+                                                                                class="views-exposed-widget views-widget-filter-date_filter">
+                                                                                <label
+                                                                                    for="date_views_exposed_filter-1efdc59efb31841d044036174ce6b00e">
+                                                                                    Event Dates </label>
+                                                                                <div class="views-widget">
+                                                                                    <div id="date_views_exposed_filter-1efdc59efb31841d044036174ce6b00e"
+                                                                                        class="form-wrapper">
+                                                                                        <div
+                                                                                            id="edit-date-filter-min-wrapper">
+                                                                                            <div
+                                                                                                id="edit-date-filter-min-inside-wrapper">
+                                                                                                <div
+                                                                                                    class="container-inline-date">
+                                                                                                    <div
+                                                                                                        class="form-item form-type-date-popup form-item-date-filter-min">
+                                                                                                        <label
+                                                                                                            class="element-invisible"
+                                                                                                            for="edit-date-filter-min">Event
+                                                                                                            Dates
+                                                                                                        </label>
+                                                                                                        <div id="edit-date-filter-min"
+                                                                                                            class="date-padding">
+                                                                                                            <div
+                                                                                                                class="form-item form-type-textfield form-item-date-filter-min-date">
+                                                                                                                <label
+                                                                                                                    class="element-invisible"
+                                                                                                                    for="edit-date-filter-min-datepicker-popup-0">Date
+                                                                                                                </label>
+                                                                                                                <input
+                                                                                                                    type="text"
+                                                                                                                    id="edit-date-filter-min-datepicker-popup-0"
+                                                                                                                    name="date_filter[min][date]"
+                                                                                                                    value="2023-02-01"
+                                                                                                                    size="20"
+                                                                                                                    maxlength="30"
+                                                                                                                    class="form-text" />
+                                                                                                                <div
+                                                                                                                    class="description">
+                                                                                                                    E.g.,
+                                                                                                                    2025-02-15
+                                                                                                                </div>
+                                                                                                            </div>
+                                                                                                        </div>
+                                                                                                    </div>
+                                                                                                </div>
+                                                                                            </div>
+                                                                                        </div>
+                                                                                        <div
+                                                                                            id="edit-date-filter-max-wrapper">
+                                                                                            <div
+                                                                                                id="edit-date-filter-max-inside-wrapper">
+                                                                                                <div
+                                                                                                    class="container-inline-date">
+                                                                                                    <div
+                                                                                                        class="form-item form-type-date-popup form-item-date-filter-max">
+                                                                                                        <label
+                                                                                                            class="element-invisible"
+                                                                                                            for="edit-date-filter-max">Event
+                                                                                                            Dates
+                                                                                                        </label>
+                                                                                                        <div id="edit-date-filter-max"
+                                                                                                            class="date-padding">
+                                                                                                            <div
+                                                                                                                class="form-item form-type-textfield form-item-date-filter-max-date">
+                                                                                                                <label
+                                                                                                                    class="element-invisible"
+                                                                                                                    for="edit-date-filter-max-datepicker-popup-0">Date
+                                                                                                                </label>
+                                                                                                                <input
+                                                                                                                    type="text"
+                                                                                                                    id="edit-date-filter-max-datepicker-popup-0"
+                                                                                                                    name="date_filter[max][date]"
+                                                                                                                    value="2026-02-15"
+                                                                                                                    size="20"
+                                                                                                                    maxlength="30"
+                                                                                                                    class="form-text" />
+                                                                                                                <div
+                                                                                                                    class="description">
+                                                                                                                    E.g.,
+                                                                                                                    2025-02-15
+                                                                                                                </div>
+                                                                                                            </div>
+                                                                                                        </div>
+                                                                                                    </div>
+                                                                                                </div>
+                                                                                            </div>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                            <div id="edit-secondary-wrapper"
+                                                                                class="views-exposed-widget views-widget-filter-secondary">
+                                                                                <div class="views-widget">
+                                                                                    <fieldset
+                                                                                        class="collapsible form-wrapper"
+                                                                                        id="edit-secondary">
+                                                                                        <legend><span
+                                                                                                class="fieldset-legend">Advanced
+                                                                                                options</span></legend>
+                                                                                        <div class="fieldset-wrapper">
+                                                                                            <div
+                                                                                                class="bef-secondary-options">
+                                                                                                <div
+                                                                                                    class="form-item form-type-select form-item-Country">
+                                                                                                    <fieldset
+                                                                                                        class="bef-select-as-checkboxes-fieldset collapsible collapsed form-wrapper">
+                                                                                                        <legend><span
+                                                                                                                class="fieldset-legend">Country</span>
+                                                                                                        </legend>
+                                                                                                        <div
+                                                                                                            class="fieldset-wrapper">
+                                                                                                            <div
+                                                                                                                class="form-checkboxes bef-select-as-checkboxes bef-select-all-none">
+                                                                                                                <div
+                                                                                                                    class="bef-checkboxes">
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-aland-islands">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-aland-islands"
+                                                                                                                            value="Aland Islands" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-aland-islands'>Aland
+                                                                                                                            Islands</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-armenia">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-armenia"
+                                                                                                                            value="Armenia" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-armenia'>Armenia</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-australia">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-australia"
+                                                                                                                            value="Australia" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-australia'>Australia</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-austria">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-austria"
+                                                                                                                            value="Austria" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-austria'>Austria</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-bahamas">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-bahamas"
+                                                                                                                            value="Bahamas" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-bahamas'>Bahamas</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-belgium">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-belgium"
+                                                                                                                            value="Belgium" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-belgium'>Belgium</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-belize">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-belize"
+                                                                                                                            value="Belize" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-belize'>Belize</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-brazil">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-brazil"
+                                                                                                                            value="Brazil" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-brazil'>Brazil</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-bulgaria">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-bulgaria"
+                                                                                                                            value="Bulgaria" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-bulgaria'>Bulgaria</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-cambodia">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-cambodia"
+                                                                                                                            value="Cambodia" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-cambodia'>Cambodia</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-canada">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-canada"
+                                                                                                                            value="Canada" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-canada'>Canada</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-china">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-china"
+                                                                                                                            value="China" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-china'>China</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-chinese-taipei">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-chinese-taipei"
+                                                                                                                            value="Chinese Taipei" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-chinese-taipei'>Chinese
+                                                                                                                            Taipei</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-colombia">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-colombia"
+                                                                                                                            value="Colombia" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-colombia'>Colombia</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-costa-rica">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-costa-rica"
+                                                                                                                            value="Costa Rica" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-costa-rica'>Costa
+                                                                                                                            Rica</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-croatia">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-croatia"
+                                                                                                                            value="Croatia" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-croatia'>Croatia</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-czech-republic">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-czech-republic"
+                                                                                                                            value="Czech Republic" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-czech-republic'>Czech
+                                                                                                                            Republic</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-denmark">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-denmark"
+                                                                                                                            value="Denmark" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-denmark'>Denmark</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-egypt">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-egypt"
+                                                                                                                            value="Egypt" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-egypt'>Egypt</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-estonia">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-estonia"
+                                                                                                                            value="Estonia" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-estonia'>Estonia</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-ethiopia">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-ethiopia"
+                                                                                                                            value="Ethiopia" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-ethiopia'>Ethiopia</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-finland">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-finland"
+                                                                                                                            value="Finland" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-finland'>Finland</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-france">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-france"
+                                                                                                                            value="France" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-france'>France</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-germany">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-germany"
+                                                                                                                            value="Germany" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-germany'>Germany</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-greece">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-greece"
+                                                                                                                            value="Greece" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-greece'>Greece</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-guatemala">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-guatemala"
+                                                                                                                            value="Guatemala" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-guatemala'>Guatemala</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-hungary">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-hungary"
+                                                                                                                            value="Hungary" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-hungary'>Hungary</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-iceland">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-iceland"
+                                                                                                                            value="Iceland" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-iceland'>Iceland</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-india">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-india"
+                                                                                                                            value="India" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-india'>India</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-ireland">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-ireland"
+                                                                                                                            value="Ireland" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-ireland'>Ireland</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-israel">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-israel"
+                                                                                                                            value="Israel" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-israel'>Israel</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-italy">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-italy"
+                                                                                                                            value="Italy" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-italy'>Italy</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-japan">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-japan"
+                                                                                                                            value="Japan" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-japan'>Japan</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-kenya">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-kenya"
+                                                                                                                            value="Kenya" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-kenya'>Kenya</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-latvia">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-latvia"
+                                                                                                                            value="Latvia" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-latvia'>Latvia</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-lithuania">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-lithuania"
+                                                                                                                            value="Lithuania" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-lithuania'>Lithuania</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-luxembourg">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-luxembourg"
+                                                                                                                            value="Luxembourg" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-luxembourg'>Luxembourg</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-malaysia">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-malaysia"
+                                                                                                                            value="Malaysia" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-malaysia'>Malaysia</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-mauritius">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-mauritius"
+                                                                                                                            value="Mauritius" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-mauritius'>Mauritius</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-mexico">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-mexico"
+                                                                                                                            value="Mexico" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-mexico'>Mexico</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-mongolia">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-mongolia"
+                                                                                                                            value="Mongolia" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-mongolia'>Mongolia</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-montenegro">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-montenegro"
+                                                                                                                            value="Montenegro" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-montenegro'>Montenegro</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-netherlands">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-netherlands"
+                                                                                                                            value="Netherlands" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-netherlands'>Netherlands</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-new-zealand">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-new-zealand"
+                                                                                                                            value="New Zealand" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-new-zealand'>New
+                                                                                                                            Zealand</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-nicaragua">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-nicaragua"
+                                                                                                                            value="Nicaragua" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-nicaragua'>Nicaragua</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-norway">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-norway"
+                                                                                                                            value="Norway" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-norway'>Norway</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-panama">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-panama"
+                                                                                                                            value="Panama" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-panama'>Panama</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-philippines">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-philippines"
+                                                                                                                            value="Philippines" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-philippines'>Philippines</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-poland">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-poland"
+                                                                                                                            value="Poland" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-poland'>Poland</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-portugal">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-portugal"
+                                                                                                                            value="Portugal" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-portugal'>Portugal</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-puerto-rico">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-puerto-rico"
+                                                                                                                            value="Puerto Rico" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-puerto-rico'>Puerto
+                                                                                                                            Rico</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-russia">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-russia"
+                                                                                                                            value="Russia" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-russia'>Russia</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-serbia">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-serbia"
+                                                                                                                            value="Serbia" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-serbia'>Serbia</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-singapore">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-singapore"
+                                                                                                                            value="Singapore" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-singapore'>Singapore</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-slovakia">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-slovakia"
+                                                                                                                            value="Slovakia" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-slovakia'>Slovakia</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-slovenia">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-slovenia"
+                                                                                                                            value="Slovenia" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-slovenia'>Slovenia</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-south-africa">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-south-africa"
+                                                                                                                            value="South Africa" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-south-africa'>South
+                                                                                                                            Africa</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-south-korea">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-south-korea"
+                                                                                                                            value="South Korea" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-south-korea'>South
+                                                                                                                            Korea</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-spain">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-spain"
+                                                                                                                            value="Spain" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-spain'>Spain</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-sweden">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-sweden"
+                                                                                                                            value="Sweden" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-sweden'>Sweden</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-switzerland">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-switzerland"
+                                                                                                                            value="Switzerland" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-switzerland'>Switzerland</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-thailand">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-thailand"
+                                                                                                                            value="Thailand" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-thailand'>Thailand</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-uganda">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-uganda"
+                                                                                                                            value="Uganda" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-uganda'>Uganda</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-ukraine">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-ukraine"
+                                                                                                                            value="Ukraine" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-ukraine'>Ukraine</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-united-kingdom">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-united-kingdom"
+                                                                                                                            value="United Kingdom" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-united-kingdom'>United
+                                                                                                                            Kingdom</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-united-states">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-united-states"
+                                                                                                                            value="United States" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-united-states'>United
+                                                                                                                            States</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-uruguay">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-uruguay"
+                                                                                                                            value="Uruguay" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-uruguay'>Uruguay</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-vietnam">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-vietnam"
+                                                                                                                            value="Vietnam" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-vietnam'>Vietnam</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-country-zambia">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Country[]"
+                                                                                                                            id="edit-country-zambia"
+                                                                                                                            value="Zambia" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-country-zambia'>Zambia</label>
+                                                                                                                    </div>
+                                                                                                                </div>
+                                                                                                            </div>
+                                                                                                        </div>
+                                                                                                    </fieldset>
+
+                                                                                                </div>
+                                                                                                <div
+                                                                                                    class="form-item form-type-select form-item-Continent">
+                                                                                                    <fieldset
+                                                                                                        class="bef-select-as-checkboxes-fieldset collapsible collapsed form-wrapper">
+                                                                                                        <legend><span
+                                                                                                                class="fieldset-legend">Continent</span>
+                                                                                                        </legend>
+                                                                                                        <div
+                                                                                                            class="fieldset-wrapper">
+                                                                                                            <div
+                                                                                                                class="form-checkboxes bef-select-as-checkboxes bef-select-all-none">
+                                                                                                                <div
+                                                                                                                    class="bef-checkboxes">
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-continent-1">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Continent[]"
+                                                                                                                            id="edit-continent-1"
+                                                                                                                            value="1" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-continent-1'>North
+                                                                                                                            America</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-continent-2">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Continent[]"
+                                                                                                                            id="edit-continent-2"
+                                                                                                                            value="2" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-continent-2'>Europe</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-continent-3">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Continent[]"
+                                                                                                                            id="edit-continent-3"
+                                                                                                                            value="3" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-continent-3'>Asia</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-continent-4">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Continent[]"
+                                                                                                                            id="edit-continent-4"
+                                                                                                                            value="4" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-continent-4'>Latin
+                                                                                                                            America/Caribbean</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-continent-5">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Continent[]"
+                                                                                                                            id="edit-continent-5"
+                                                                                                                            value="5" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-continent-5'>Oceania</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-continent-6">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Continent[]"
+                                                                                                                            id="edit-continent-6"
+                                                                                                                            value="6" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-continent-6'>Africa</label>
+                                                                                                                    </div>
+                                                                                                                </div>
+                                                                                                            </div>
+                                                                                                        </div>
+                                                                                                    </fieldset>
+
+                                                                                                </div>
+                                                                                                <div
+                                                                                                    class="form-item form-type-select form-item-State">
+                                                                                                    <fieldset
+                                                                                                        class="bef-select-as-checkboxes-fieldset collapsible form-wrapper">
+                                                                                                        <legend><span
+                                                                                                                class="fieldset-legend">State
+                                                                                                                (USA)</span>
+                                                                                                        </legend>
+                                                                                                        <div
+                                                                                                            class="fieldset-wrapper">
+                                                                                                            <div
+                                                                                                                class="form-checkboxes bef-select-as-checkboxes bef-select-all-none">
+                                                                                                                <div
+                                                                                                                    class="bef-checkboxes">
+                                                                                                                    <div
+                                                                                                                        class="bef-group">
+                                                                                                                        <div
+                                                                                                                            class="bef-group-heading">
+                                                                                                                            USA
+                                                                                                                        </div>
+                                                                                                                        <div
+                                                                                                                            class="bef-group-items">
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-al">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-al"
+                                                                                                                                    value="AL" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-al'>Alabama</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-ak">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-ak"
+                                                                                                                                    value="AK" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-ak'>Alaska</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-az">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-az"
+                                                                                                                                    value="AZ" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-az'>Arizona</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-ar">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-ar"
+                                                                                                                                    value="AR" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-ar'>Arkansas</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-ca">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-ca"
+                                                                                                                                    value="CA" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-ca'>California</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-co">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-co"
+                                                                                                                                    value="CO" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-co'>Colorado</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-ct">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-ct"
+                                                                                                                                    value="CT" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-ct'>Connecticut</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-de">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-de"
+                                                                                                                                    value="DE" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-de'>Delaware</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-dc">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-dc"
+                                                                                                                                    value="DC" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-dc'>District
+                                                                                                                                    Of
+                                                                                                                                    Columbia</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-fl">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-fl"
+                                                                                                                                    value="FL" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-fl'>Florida</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-ga">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-ga"
+                                                                                                                                    value="GA" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-ga'>Georgia</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-hi">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-hi"
+                                                                                                                                    value="HI" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-hi'>Hawaii</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-id">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-id"
+                                                                                                                                    value="ID" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-id'>Idaho</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-il">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-il"
+                                                                                                                                    value="IL" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-il'>Illinois</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-in">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-in"
+                                                                                                                                    value="IN" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-in'>Indiana</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-ia">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-ia"
+                                                                                                                                    value="IA" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-ia'>Iowa</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-ks">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-ks"
+                                                                                                                                    value="KS" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-ks'>Kansas</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-ky">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-ky"
+                                                                                                                                    value="KY" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-ky'>Kentucky</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-la">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-la"
+                                                                                                                                    value="LA" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-la'>Louisiana</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-me">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-me"
+                                                                                                                                    value="ME" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-me'>Maine</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-md">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-md"
+                                                                                                                                    value="MD" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-md'>Maryland</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-ma">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-ma"
+                                                                                                                                    value="MA" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-ma'>Massachusetts</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-mi">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-mi"
+                                                                                                                                    value="MI" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-mi'>Michigan</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-mn">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-mn"
+                                                                                                                                    value="MN" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-mn'>Minnesota</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-ms">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-ms"
+                                                                                                                                    value="MS" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-ms'>Mississippi</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-mo">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-mo"
+                                                                                                                                    value="MO" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-mo'>Missouri</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-mt">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-mt"
+                                                                                                                                    value="MT" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-mt'>Montana</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-ne">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-ne"
+                                                                                                                                    value="NE" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-ne'>Nebraska</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-nv">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-nv"
+                                                                                                                                    value="NV" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-nv'>Nevada</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-nh">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-nh"
+                                                                                                                                    value="NH" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-nh'>New
+                                                                                                                                    Hampshire</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-nj">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-nj"
+                                                                                                                                    value="NJ" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-nj'>New
+                                                                                                                                    Jersey</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-nm">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-nm"
+                                                                                                                                    value="NM" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-nm'>New
+                                                                                                                                    Mexico</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-ny">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-ny"
+                                                                                                                                    value="NY" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-ny'>New
+                                                                                                                                    York</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-nc">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-nc"
+                                                                                                                                    value="NC" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-nc'>North
+                                                                                                                                    Carolina</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-nd">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-nd"
+                                                                                                                                    value="ND" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-nd'>North
+                                                                                                                                    Dakota</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-oh">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-oh"
+                                                                                                                                    value="OH" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-oh'>Ohio</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-ok">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-ok"
+                                                                                                                                    value="OK" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-ok'>Oklahoma</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-or">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-or"
+                                                                                                                                    value="OR" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-or'>Oregon</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-pa">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-pa"
+                                                                                                                                    value="PA"
+                                                                                                                                    checked="checked" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-pa'>Pennsylvania</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-ri">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-ri"
+                                                                                                                                    value="RI" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-ri'>Rhode
+                                                                                                                                    Island</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-sc">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-sc"
+                                                                                                                                    value="SC" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-sc'>South
+                                                                                                                                    Carolina</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-sd">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-sd"
+                                                                                                                                    value="SD" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-sd'>South
+                                                                                                                                    Dakota</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-tn">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-tn"
+                                                                                                                                    value="TN" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-tn'>Tennessee</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-tx">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-tx"
+                                                                                                                                    value="TX" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-tx'>Texas</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-ut">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-ut"
+                                                                                                                                    value="UT" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-ut'>Utah</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-vt">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-vt"
+                                                                                                                                    value="VT" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-vt'>Vermont</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-va">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-va"
+                                                                                                                                    value="VA" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-va'>Virginia</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-wa">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-wa"
+                                                                                                                                    value="WA" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-wa'>Washington</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-wv">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-wv"
+                                                                                                                                    value="WV" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-wv'>West
+                                                                                                                                    Virginia</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-wi">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-wi"
+                                                                                                                                    value="WI" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-wi'>Wisconsin</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-wy">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State[]"
+                                                                                                                                    id="edit-state-wy"
+                                                                                                                                    value="WY" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-wy'>Wyoming</label>
+                                                                                                                            </div>
+                                                                                                                        </div>
+                                                                                                                    </div>
+                                                                                                                </div>
+                                                                                                            </div>
+                                                                                                        </div>
+                                                                                                    </fieldset>
+
+                                                                                                </div>
+                                                                                                <div
+                                                                                                    class="form-item form-type-select form-item-State-1">
+                                                                                                    <fieldset
+                                                                                                        class="bef-select-as-checkboxes-fieldset collapsible collapsed form-wrapper">
+                                                                                                        <legend><span
+                                                                                                                class="fieldset-legend">Province
+                                                                                                                (Canada)</span>
+                                                                                                        </legend>
+                                                                                                        <div
+                                                                                                            class="fieldset-wrapper">
+                                                                                                            <div
+                                                                                                                class="form-checkboxes bef-select-as-checkboxes bef-select-all-none">
+                                                                                                                <div
+                                                                                                                    class="bef-checkboxes">
+                                                                                                                    <div
+                                                                                                                        class="bef-group">
+                                                                                                                        <div
+                                                                                                                            class="bef-group-heading">
+                                                                                                                            Canada
+                                                                                                                        </div>
+                                                                                                                        <div
+                                                                                                                            class="bef-group-items">
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-1-ab">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State_1[]"
+                                                                                                                                    id="edit-state-1-ab"
+                                                                                                                                    value="AB" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-1-ab'>Alberta</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-1-bc">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State_1[]"
+                                                                                                                                    id="edit-state-1-bc"
+                                                                                                                                    value="BC" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-1-bc'>British
+                                                                                                                                    Columbia</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-1-mb">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State_1[]"
+                                                                                                                                    id="edit-state-1-mb"
+                                                                                                                                    value="MB" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-1-mb'>Manitoba</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-1-nb">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State_1[]"
+                                                                                                                                    id="edit-state-1-nb"
+                                                                                                                                    value="NB" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-1-nb'>New
+                                                                                                                                    Brunswick</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-1-nl">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State_1[]"
+                                                                                                                                    id="edit-state-1-nl"
+                                                                                                                                    value="NL" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-1-nl'>Newfoundland
+                                                                                                                                    and
+                                                                                                                                    Labrador</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-1-nt">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State_1[]"
+                                                                                                                                    id="edit-state-1-nt"
+                                                                                                                                    value="NT" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-1-nt'>Northwest
+                                                                                                                                    Territories</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-1-ns">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State_1[]"
+                                                                                                                                    id="edit-state-1-ns"
+                                                                                                                                    value="NS" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-1-ns'>Nova
+                                                                                                                                    Scotia</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-1-nu">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State_1[]"
+                                                                                                                                    id="edit-state-1-nu"
+                                                                                                                                    value="NU" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-1-nu'>Nunavut</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-1-on">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State_1[]"
+                                                                                                                                    id="edit-state-1-on"
+                                                                                                                                    value="ON" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-1-on'>Ontario</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-1-pe">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State_1[]"
+                                                                                                                                    id="edit-state-1-pe"
+                                                                                                                                    value="PE" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-1-pe'>Prince
+                                                                                                                                    Edward
+                                                                                                                                    Island</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-1-qc">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State_1[]"
+                                                                                                                                    id="edit-state-1-qc"
+                                                                                                                                    value="QC" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-1-qc'>Quebec</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-1-sk">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State_1[]"
+                                                                                                                                    id="edit-state-1-sk"
+                                                                                                                                    value="SK" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-1-sk'>Saskatchewan</label>
+                                                                                                                            </div>
+                                                                                                                            <div
+                                                                                                                                class="form-item form-type-bef-checkbox form-item-edit-state-1-yt">
+                                                                                                                                <input
+                                                                                                                                    type="checkbox"
+                                                                                                                                    name="State_1[]"
+                                                                                                                                    id="edit-state-1-yt"
+                                                                                                                                    value="YT" />
+                                                                                                                                <label
+                                                                                                                                    class='option'
+                                                                                                                                    for='edit-state-1-yt'>Yukon
+                                                                                                                                    Territory</label>
+                                                                                                                            </div>
+                                                                                                                        </div>
+                                                                                                                    </div>
+                                                                                                                </div>
+                                                                                                            </div>
+                                                                                                        </div>
+                                                                                                    </fieldset>
+
+                                                                                                </div>
+                                                                                                <div
+                                                                                                    class="form-item form-type-select form-item-Tier">
+                                                                                                    <fieldset
+                                                                                                        class="bef-select-as-checkboxes-fieldset collapsible form-wrapper">
+                                                                                                        <legend><span
+                                                                                                                class="fieldset-legend">Tier</span>
+                                                                                                        </legend>
+                                                                                                        <div
+                                                                                                            class="fieldset-wrapper">
+                                                                                                            <div
+                                                                                                                class="form-checkboxes bef-select-as-checkboxes bef-select-all-none">
+                                                                                                                <div
+                                                                                                                    class="bef-checkboxes">
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-tier-a">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Tier[]"
+                                                                                                                            id="edit-tier-a"
+                                                                                                                            value="A"
+                                                                                                                            checked="checked" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-tier-a'>A</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-tier-ab">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Tier[]"
+                                                                                                                            id="edit-tier-ab"
+                                                                                                                            value="A/B" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-tier-ab'>A/B</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-tier-ac">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Tier[]"
+                                                                                                                            id="edit-tier-ac"
+                                                                                                                            value="A/C" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-tier-ac'>A/C</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-tier-b">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Tier[]"
+                                                                                                                            id="edit-tier-b"
+                                                                                                                            value="B"
+                                                                                                                            checked="checked" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-tier-b'>B</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-tier-ba">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Tier[]"
+                                                                                                                            id="edit-tier-ba"
+                                                                                                                            value="B/A" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-tier-ba'>B/A</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-tier-bc">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Tier[]"
+                                                                                                                            id="edit-tier-bc"
+                                                                                                                            value="B/C" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-tier-bc'>B/C</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-tier-c">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Tier[]"
+                                                                                                                            id="edit-tier-c"
+                                                                                                                            value="C"
+                                                                                                                            checked="checked" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-tier-c'>C</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-tier-ca">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Tier[]"
+                                                                                                                            id="edit-tier-ca"
+                                                                                                                            value="C/A" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-tier-ca'>C/A</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-tier-cb">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Tier[]"
+                                                                                                                            id="edit-tier-cb"
+                                                                                                                            value="C/B" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-tier-cb'>C/B</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-tier-d">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Tier[]"
+                                                                                                                            id="edit-tier-d"
+                                                                                                                            value="D" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-tier-d'>D</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-tier-es">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Tier[]"
+                                                                                                                            id="edit-tier-es"
+                                                                                                                            value="ES" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-tier-es'>ES</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-tier-h">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Tier[]"
+                                                                                                                            id="edit-tier-h"
+                                                                                                                            value="H" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-tier-h'>H</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-tier-l">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Tier[]"
+                                                                                                                            id="edit-tier-l"
+                                                                                                                            value="L" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-tier-l'>L</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-tier-m">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Tier[]"
+                                                                                                                            id="edit-tier-m"
+                                                                                                                            value="M" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-tier-m'>M</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-tier-nt">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Tier[]"
+                                                                                                                            id="edit-tier-nt"
+                                                                                                                            value="NT" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-tier-nt'>NT</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-tier-w">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Tier[]"
+                                                                                                                            id="edit-tier-w"
+                                                                                                                            value="W" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-tier-w'>W</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-tier-xa">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Tier[]"
+                                                                                                                            id="edit-tier-xa"
+                                                                                                                            value="XA" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-tier-xa'>XA</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-tier-xb">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Tier[]"
+                                                                                                                            id="edit-tier-xb"
+                                                                                                                            value="XB" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-tier-xb'>XB</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-tier-xc">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Tier[]"
+                                                                                                                            id="edit-tier-xc"
+                                                                                                                            value="XC" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-tier-xc'>XC</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-tier-xm">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Tier[]"
+                                                                                                                            id="edit-tier-xm"
+                                                                                                                            value="XM" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-tier-xm'>XM</label>
+                                                                                                                    </div>
+                                                                                                                </div>
+                                                                                                            </div>
+                                                                                                        </div>
+                                                                                                    </fieldset>
+
+                                                                                                </div>
+                                                                                                <div
+                                                                                                    class="form-item form-type-select form-item-Classification">
+                                                                                                    <fieldset
+                                                                                                        class="bef-select-as-checkboxes-fieldset collapsible collapsed form-wrapper">
+                                                                                                        <legend><span
+                                                                                                                class="fieldset-legend">Classification</span>
+                                                                                                        </legend>
+                                                                                                        <div
+                                                                                                            class="fieldset-wrapper">
+                                                                                                            <div
+                                                                                                                class="form-checkboxes bef-select-as-checkboxes bef-select-all-none">
+                                                                                                                <div
+                                                                                                                    class="bef-checkboxes">
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-classification-pro">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Classification[]"
+                                                                                                                            id="edit-classification-pro"
+                                                                                                                            value="Pro" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-classification-pro'>Pro</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-classification-am">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Classification[]"
+                                                                                                                            id="edit-classification-am"
+                                                                                                                            value="Am" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-classification-am'>Am</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-classification-pro-am">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="Classification[]"
+                                                                                                                            id="edit-classification-pro-am"
+                                                                                                                            value="Pro-Am" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-classification-pro-am'>Pro-Am</label>
+                                                                                                                    </div>
+                                                                                                                </div>
+                                                                                                            </div>
+                                                                                                        </div>
+                                                                                                    </fieldset>
+
+                                                                                                </div>
+                                                                                                <div
+                                                                                                    class="form-item form-type-select form-item-EventType">
+                                                                                                    <fieldset
+                                                                                                        class="bef-select-as-checkboxes-fieldset collapsible collapsed form-wrapper">
+                                                                                                        <legend><span
+                                                                                                                class="fieldset-legend">Type</span>
+                                                                                                        </legend>
+                                                                                                        <div
+                                                                                                            class="fieldset-wrapper">
+                                                                                                            <div
+                                                                                                                class="form-checkboxes bef-select-as-checkboxes bef-select-all-none">
+                                                                                                                <div
+                                                                                                                    class="bef-checkboxes">
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-eventtype-w">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="EventType[]"
+                                                                                                                            id="edit-eventtype-w"
+                                                                                                                            value="W" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-eventtype-w'>Women</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-eventtype-j">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="EventType[]"
+                                                                                                                            id="edit-eventtype-j"
+                                                                                                                            value="J" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-eventtype-j'>Junior</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-eventtype-s">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="EventType[]"
+                                                                                                                            id="edit-eventtype-s"
+                                                                                                                            value="S" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-eventtype-s'>Senior</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-eventtype-c">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="EventType[]"
+                                                                                                                            id="edit-eventtype-c"
+                                                                                                                            value="C" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-eventtype-c'>Collegiate</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-eventtype-e">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="EventType[]"
+                                                                                                                            id="edit-eventtype-e"
+                                                                                                                            value="E" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-eventtype-e'>Elite</label>
+                                                                                                                    </div>
+                                                                                                                    <div
+                                                                                                                        class="form-item form-type-bef-checkbox form-item-edit-eventtype-et">
+                                                                                                                        <input
+                                                                                                                            type="checkbox"
+                                                                                                                            name="EventType[]"
+                                                                                                                            id="edit-eventtype-et"
+                                                                                                                            value="ET" />
+                                                                                                                        <label
+                                                                                                                            class='option'
+                                                                                                                            for='edit-eventtype-et'>EuroTour</label>
+                                                                                                                    </div>
+                                                                                                                </div>
+                                                                                                            </div>
+                                                                                                        </div>
+                                                                                                    </fieldset>
+
+                                                                                                </div>
+                                                                                                <input type="submit"
+                                                                                                    id="edit-submit-pdga-tournament-list"
+                                                                                                    value="Apply"
+                                                                                                    class="form-submit" /><input
+                                                                                                    type="submit"
+                                                                                                    id="edit-reset"
+                                                                                                    name="op"
+                                                                                                    value="Reset"
+                                                                                                    class="form-submit" />
+                                                                                            </div>
+                                                                                        </div>
+                                                                                    </fieldset>
+                                                                                </div>
+                                                                            </div>
+                                                                            <div
+                                                                                class="views-exposed-widget views-submit-button">
+                                                                                <input type="submit"
+                                                                                    id="edit-submit-pdga-tournament-list"
+                                                                                    value="Apply"
+                                                                                    class="form-submit" /><input
+                                                                                    type="submit" id="edit-reset--2"
+                                                                                    name="op" value="Reset"
+                                                                                    class="form-submit" />
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </form>
+                                                        </div>
+
+
+                                                    </div>
+                                                    <div class="panel-separator"></div>
+                                                    <div class="panel-pane pane-views-panes pane-pdga-tournament-list-panel-pane-1"
+                                                        class="panel-pane pane-views-panes pane-pdga-tournament-list-panel-pane-1">
+
+
+
+                                                        <div class="pane-content">
+                                                            <div
+                                                                class="view view-pdga-tournament-list view-id-pdga_tournament_list view-display-id-panel_pane_1 view-dom-id-bd0da36c15864d2a05d7f05b0b6adb7a">
+
+
+
+                                                                <div class="view-content">
+                                                                    <div class="table-container">
+                                                                        <table class="views-table cols-8"
+                                                                            class="views-table cols-8">
+                                                                            <thead>
+                                                                                <tr>
+                                                                                    <th
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/search?date_filter%5Bmin%5D%5Bdate%5D=2023-02-01&amp;State%5B0%5D=PA&amp;Tier%5B0%5D=A&amp;Tier%5B1%5D=B&amp;Tier%5B2%5D=C&amp;page=1&amp;order=OfficialName&amp;sort=asc"
+                                                                                            title="sort by Name"
+                                                                                            class="active">Name</a>
+                                                                                    </th>
+                                                                                    <th
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        Status </th>
+                                                                                    <th
+                                                                                        class="views-field views-field-Classification">
+                                                                                        <a href="/tour/search?date_filter%5Bmin%5D%5Bdate%5D=2023-02-01&amp;State%5B0%5D=PA&amp;Tier%5B0%5D=A&amp;Tier%5B1%5D=B&amp;Tier%5B2%5D=C&amp;page=1&amp;order=Classification&amp;sort=asc"
+                                                                                            title="sort by Class"
+                                                                                            class="active">Class</a>
+                                                                                    </th>
+                                                                                    <th
+                                                                                        class="views-field views-field-Tier">
+                                                                                        <a href="/tour/search?date_filter%5Bmin%5D%5Bdate%5D=2023-02-01&amp;State%5B0%5D=PA&amp;Tier%5B0%5D=A&amp;Tier%5B1%5D=B&amp;Tier%5B2%5D=C&amp;page=1&amp;order=Tier&amp;sort=asc"
+                                                                                            title="sort by Tier"
+                                                                                            class="active">Tier</a>
+                                                                                    </th>
+                                                                                    <th
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        Tournament Director </th>
+                                                                                    <th
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                        Asst. Tournament Director </th>
+                                                                                    <th
+                                                                                        class="views-field views-field-Location">
+                                                                                        Location </th>
+                                                                                    <th
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        Dates </th>
+                                                                                </tr>
+                                                                            </thead>
+                                                                            <tbody>
+                                                                                <tr
+                                                                                    class="odd tid-67646 tier-C type-N status-Sanctioned nt-no views-row-first">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/67646">Sedgley
+                                                                                            Easter</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/67646"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/48144">Brian
+                                                                                            Bochantin #48144</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                        <a href="/player/238845">Audrey
+                                                                                            Bochantin #238845</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Philadelphia, Pennsylvania,
+                                                                                        United States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 9, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="even tid-69450 tier-C type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/69450">Gatekeeper
+                                                                                            Media Flex Start at South
+                                                                                            Mountain</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/69450"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/40274">Nick
+                                                                                            Hanson #40274</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Bethlehem, Pennsylvania, United
+                                                                                        States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 13, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="odd tid-69661 tier-C type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/69661">Freaky
+                                                                                            Friday - Cubby Weekend</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/69661"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/32429">Michael
+                                                                                            Solt #32429</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Pine Grove, Pennsylvania, United
+                                                                                        States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 14, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="even tid-69662 tier-C type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/69662">The
+                                                                                            Cubby 2023</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/69662"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/32429">Michael
+                                                                                            Solt #32429</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Pine Grove, Pennsylvania, United
+                                                                                        States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 15, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="odd tid-67180 tier-C type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/67180">Boulder
+                                                                                            Bash</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/67180"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/95094">Cody
+                                                                                            Book #95094</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Wellsville, Pennsylvania, United
+                                                                                        States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 15, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="even tid-68172 tier-C type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/68172">The
+                                                                                            Hellraiser</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/68172"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/47356">Kurt
+                                                                                            DeMarra #47356</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Lancaster, Pennsylvania, United
+                                                                                        States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 16, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="odd tid-67944 tier-C type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/67944">The
+                                                                                            81FORE Classic - Presented
+                                                                                            by Chains Or Dye Disc
+                                                                                            Golf</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/67944"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/112548">Howie
+                                                                                            Kocher #112548</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Girard , Pennsylvania, United
+                                                                                        States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 16, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="even tid-66090 tier-B type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/66090">The
+                                                                                            Faylor Lake Open Presented
+                                                                                            by Discmania</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/66090"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        B </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/106753">Andy
+                                                                                            Klinger #106753</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Beaver Springs, Pennsylvania,
+                                                                                        United States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 21 - 22, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="odd tid-68723 tier-C type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/68723">Red
+                                                                                            Rose Roundup - Fairview Park
+                                                                                            2023</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/68723"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/77900">Shawn
+                                                                                            Conroy #77900</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Columbia, Pennsylvania, United
+                                                                                        States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 22, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="even tid-67647 tier-C type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/67647">Laurelain
+                                                                                            Clasic</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/67647"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/48144">Brian
+                                                                                            Bochantin #48144</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                        <a href="/player/238845">Audrey
+                                                                                            Bochantin #238845</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Reading, Pennsylvania, United
+                                                                                        States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 22, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="odd tid-67081 tier-C type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/67081">Oak
+                                                                                            Hollow Spring Open Sponsored
+                                                                                            by MVP Disc Sports</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/67081"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/39732">Dan
+                                                                                            Flannigan #39732</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        North Huntingdon, Pennsylvania,
+                                                                                        United States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 22, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="even tid-66151 tier-C type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/66151">Early
+                                                                                            Bird Open 2023 - sponsored
+                                                                                            by Discraft - All Other
+                                                                                            Divisions</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/66151"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/56033">Trevor
+                                                                                            Murphy #56033</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                        <a href="/player/60734">Tricia
+                                                                                            Lafferty #60734</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Hermitage, Pennsylvania, United
+                                                                                        States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 22, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="odd tid-67836 tier-C type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/67836">DGOPA
+                                                                                            - Warm Up #1</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/67836"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/130735">Eric
+                                                                                            Hess #130735</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                        <a href="/player/133513">Kayla
+                                                                                            Hess #133513</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Lancaster , Pennsylvania, United
+                                                                                        States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 23, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="even tid-67651 tier-C type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/67651">West
+                                                                                            Reading Upshot</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/67651"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/48144">Brian
+                                                                                            Bochantin #48144</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                        <a href="/player/238845">Audrey
+                                                                                            Bochantin #238845</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        West Reading, Pennsylvania,
+                                                                                        United States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 23, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="odd tid-67004 tier-C type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/67004">2023
+                                                                                            Silent Spring</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/67004"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/171584">Emily
+                                                                                            Dale #171584</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                        <a href="/player/133513">Kayla
+                                                                                            Hess #133513</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Lancaster, Pennsylvania, United
+                                                                                        States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 23, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="even tid-66161 tier-C type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/66161">Early
+                                                                                            Bird Open 2023 - sponsored
+                                                                                            by Discraft - MA2, MA3, MA4,
+                                                                                            &amp; Juniors</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/66161"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/56033">Trevor
+                                                                                            Murphy #56033</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                        <a href="/player/60734">Tricia
+                                                                                            Lafferty #60734</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Hermitage, Pennsylvania, United
+                                                                                        States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 23, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="odd tid-68335 tier-C type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/68335">Birdie
+                                                                                            Presents: The Basket Case at
+                                                                                            Broken Chains -
+                                                                                            Pro/MA1/MA40+</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/68335"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/27937">Tim
+                                                                                            Reyes #27937</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Lincoln University,
+                                                                                        Pennsylvania, United States
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 29, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="even tid-67653 tier-C type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/67653">Pinebrook
+                                                                                            Upshot</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/67653"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/48144">Brian
+                                                                                            Bochantin #48144</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                        <a href="/player/238845">Audrey
+                                                                                            Bochantin #238845</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        East Stroudsburg, Pennsylvania,
+                                                                                        United States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 29, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="odd tid-67001 tier-B type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/67001">2023
+                                                                                            NADGT Exclusive @ Lenni
+                                                                                            Lenape</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/67001"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        B </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/104989">Mike
+                                                                                            Snyder #104989</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Lebanon, Pennsylvania, United
+                                                                                        States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 29, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="even tid-66621 tier-C type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/66621">The
+                                                                                            16th Whispering Falls
+                                                                                            Harvest, I81DGS</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/66621"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/27920">Brad
+                                                                                            Lescalleet #27920</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Greencastle, Pennsylvania,
+                                                                                        United States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 29, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="odd tid-66410 tier-C type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/66410">Queen
+                                                                                            of the Mountain</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/66410"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/13217">Richie
+                                                                                            Klinger #13217</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                        <a href="/player/47869">Marci
+                                                                                            Klinger #47869</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Bethlehem, Pennsylvania, United
+                                                                                        States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 29, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="even tid-66208 tier-B type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/66208">Coyote
+                                                                                            Howler</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/66208"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        B </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/70347">Daniel
+                                                                                            Radosinovich #70347</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Carlisle, Pennsylvania, United
+                                                                                        States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 29, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="odd tid-68536 tier-C type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/68536">DGOPA
+                                                                                            Warmup #2</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/68536"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/130735">Eric
+                                                                                            Hess #130735</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Lancaster, Pennsylvania, United
+                                                                                        States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 30, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="even tid-68339 tier-C type-N status-Sanctioned nt-no">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/68339">Birdie
+                                                                                            Presents: The Basket Case at
+                                                                                            Broken Chains - All Other
+                                                                                            Ams</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/68339"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        C </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/27937">Tim
+                                                                                            Reyes #27937</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Lincoln University,
+                                                                                        Pennsylvania, United States
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 30, 2023 </td>
+                                                                                </tr>
+                                                                                <tr
+                                                                                    class="odd tid-65634 tier-B type-N status-Sanctioned nt-no views-row-last">
+                                                                                    <td
+                                                                                        class="views-field views-field-OfficialName">
+                                                                                        <a href="/tour/event/65634">2023
+                                                                                            Codorus Spring Open
+                                                                                            Presented by MVP Disc
+                                                                                            Sports</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StatusIcons">
+                                                                                        <a href="/tour/event/65634"><img
+                                                                                                typeof="foaf:Image"
+                                                                                                src="https://www.pdga.com/sites/all/modules/custom/tournament/img/trophy.gif"
+                                                                                                alt="Official Tournament Results"
+                                                                                                title="Official Tournament Results" /></a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Classification">
+                                                                                        Pro-Am </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Tier">
+                                                                                        B </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-TDPDGANum">
+                                                                                        <a href="/player/41797">Zachary
+                                                                                            Anders #41797</a>
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-AsstTDPDGANum">
+                                                                                    </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-Location">
+                                                                                        Hanover, Pennsylvania, United
+                                                                                        States </td>
+                                                                                    <td
+                                                                                        class="views-field views-field-StartDate">
+                                                                                        April 30, 2023 </td>
+                                                                                </tr>
+                                                                            </tbody>
+                                                                        </table>
+                                                                    </div>
+                                                                </div>
+
+                                                                <h2 class="element-invisible">Pages</h2>
+                                                                <div class="item-list">
+                                                                    <ul class="pager clearfix">
+                                                                        <li class="pager-first first"><a
+                                                                                title="Go to first page"
+                                                                                href="/tour/search?date_filter%5Bmin%5D%5Bdate%5D=2023-02-01&amp;State%5B0%5D=PA&amp;Tier%5B0%5D=A&amp;Tier%5B1%5D=B&amp;Tier%5B2%5D=C">«
+                                                                                first</a></li>
+                                                                        <li class="pager-previous"><a
+                                                                                title="Go to previous page"
+                                                                                href="/tour/search?date_filter%5Bmin%5D%5Bdate%5D=2023-02-01&amp;State%5B0%5D=PA&amp;Tier%5B0%5D=A&amp;Tier%5B1%5D=B&amp;Tier%5B2%5D=C">‹
+                                                                                previous</a></li>
+                                                                        <li class="pager-item"><a title="Go to page 1"
+                                                                                href="/tour/search?date_filter%5Bmin%5D%5Bdate%5D=2023-02-01&amp;State%5B0%5D=PA&amp;Tier%5B0%5D=A&amp;Tier%5B1%5D=B&amp;Tier%5B2%5D=C">1</a>
+                                                                        </li>
+                                                                        <li class="pager-current">2</li>
+                                                                        <li class="pager-item"><a title="Go to page 3"
+                                                                                href="/tour/search?date_filter%5Bmin%5D%5Bdate%5D=2023-02-01&amp;State%5B0%5D=PA&amp;Tier%5B0%5D=A&amp;Tier%5B1%5D=B&amp;Tier%5B2%5D=C&amp;page=2">3</a>
+                                                                        </li>
+                                                                        <li class="pager-item"><a title="Go to page 4"
+                                                                                href="/tour/search?date_filter%5Bmin%5D%5Bdate%5D=2023-02-01&amp;State%5B0%5D=PA&amp;Tier%5B0%5D=A&amp;Tier%5B1%5D=B&amp;Tier%5B2%5D=C&amp;page=3">4</a>
+                                                                        </li>
+                                                                        <li class="pager-item"><a title="Go to page 5"
+                                                                                href="/tour/search?date_filter%5Bmin%5D%5Bdate%5D=2023-02-01&amp;State%5B0%5D=PA&amp;Tier%5B0%5D=A&amp;Tier%5B1%5D=B&amp;Tier%5B2%5D=C&amp;page=4">5</a>
+                                                                        </li>
+                                                                        <li class="pager-item"><a title="Go to page 6"
+                                                                                href="/tour/search?date_filter%5Bmin%5D%5Bdate%5D=2023-02-01&amp;State%5B0%5D=PA&amp;Tier%5B0%5D=A&amp;Tier%5B1%5D=B&amp;Tier%5B2%5D=C&amp;page=5">6</a>
+                                                                        </li>
+                                                                        <li class="pager-item"><a title="Go to page 7"
+                                                                                href="/tour/search?date_filter%5Bmin%5D%5Bdate%5D=2023-02-01&amp;State%5B0%5D=PA&amp;Tier%5B0%5D=A&amp;Tier%5B1%5D=B&amp;Tier%5B2%5D=C&amp;page=6">7</a>
+                                                                        </li>
+                                                                        <li class="pager-item"><a title="Go to page 8"
+                                                                                href="/tour/search?date_filter%5Bmin%5D%5Bdate%5D=2023-02-01&amp;State%5B0%5D=PA&amp;Tier%5B0%5D=A&amp;Tier%5B1%5D=B&amp;Tier%5B2%5D=C&amp;page=7">8</a>
+                                                                        </li>
+                                                                        <li class="pager-item"><a title="Go to page 9"
+                                                                                href="/tour/search?date_filter%5Bmin%5D%5Bdate%5D=2023-02-01&amp;State%5B0%5D=PA&amp;Tier%5B0%5D=A&amp;Tier%5B1%5D=B&amp;Tier%5B2%5D=C&amp;page=8">9</a>
+                                                                        </li>
+                                                                        <li class="pager-ellipsis">…</li>
+                                                                        <li class="pager-next"><a
+                                                                                title="Go to next page"
+                                                                                href="/tour/search?date_filter%5Bmin%5D%5Bdate%5D=2023-02-01&amp;State%5B0%5D=PA&amp;Tier%5B0%5D=A&amp;Tier%5B1%5D=B&amp;Tier%5B2%5D=C&amp;page=2">next
+                                                                                ›</a></li>
+                                                                        <li class="pager-last last"><a
+                                                                                title="Go to last page"
+                                                                                href="/tour/search?date_filter%5Bmin%5D%5Bdate%5D=2023-02-01&amp;State%5B0%5D=PA&amp;Tier%5B0%5D=A&amp;Tier%5B1%5D=B&amp;Tier%5B2%5D=C&amp;page=18">last
+                                                                                »</a></li>
+                                                                    </ul>
+                                                                </div>
+
+
+                                                                <div class="view-footer">
+                                                                    <p>Displaying 26 - 50 of 451</p>
+                                                                </div>
+
+
+                                                            </div>
+                                                        </div>
+
+
+                                                    </div>
+                                                </div>
+                                            </div>
+
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <footer id="section-footer" class="section section-footer">
+            <div id="zone-footer-wrapper" class="zone-wrapper zone-footer-wrapper clearfix">
+                <div id="zone-footer" class="zone zone-footer clearfix container-12">
+                    <div class="grid-12 region region-footer-first" id="region-footer-first">
+                        <div class="region-inner region-footer-first-inner">
+                            <div class="block block-panels-mini block-footer-menu block-panels-mini-footer-menu odd block-without-title"
+                                id="block-panels-mini-footer-menu">
+                                <div class="block-inner clearfix">
+
+                                    <div class="content clearfix">
+                                        <div class="panel-display panel-1col clearfix" id="mini-panel-footer_menu">
+                                            <div class="panel-panel panel-col">
+                                                <div>
+                                                    <div class="panel-pane pane-block pane-menu-menu-footer clearfix"
+                                                        class="panel-pane pane-block pane-menu-menu-footer clearfix">
+
+
+
+                                                        <div class="pane-content">
+                                                            <ul class="menu">
+                                                                <li class="first expanded">
+                                                                    <div class="nolink" tabindex="0">Disc Golf</div>
+                                                                    <ul class="menu">
+                                                                        <li class="first leaf"><a href="/introduction"
+                                                                                title="">What is Disc Golf</a></li>
+                                                                        <li class="leaf"><a href="/history"
+                                                                                title="">History of Disc Golf</a></li>
+                                                                        <li class="leaf"><a href="/rules">Official Rules
+                                                                                of Disc Golf</a></li>
+                                                                        <li class="leaf"><a href="/code">Disc
+                                                                                Golfer&#039;s Code</a></li>
+                                                                        <li class="last leaf"><a
+                                                                                href="/course-directory">Course
+                                                                                Directory</a></li>
+                                                                    </ul>
+                                                                </li>
+                                                                <li class="expanded">
+                                                                    <div class="nolink" tabindex="0">Membership</div>
+                                                                    <ul class="menu">
+                                                                        <li class="first leaf"><a href="/membership"
+                                                                                title="">Join &amp; Renew</a></li>
+                                                                        <li class="leaf"><a
+                                                                                href="/members/benefits">Benefits</a>
+                                                                        </li>
+                                                                        <li class="leaf"><a href="/players"
+                                                                                title="">Member Search</a></li>
+                                                                        <li class="leaf"><a href="/players/stats"
+                                                                                title="">Player Statistics</a></li>
+                                                                        <li class="last leaf"><a
+                                                                                href="/faq/membership-0"
+                                                                                title="">Frequently Asked Questions</a>
+                                                                        </li>
+                                                                    </ul>
+                                                                </li>
+                                                                <li class="expanded">
+                                                                    <div class="nolink" tabindex="0">Tour</div>
+                                                                    <ul class="menu">
+                                                                        <li class="first leaf"><a href="/tour/events"
+                                                                                title="">Schedule &amp; Results</a></li>
+                                                                        <li class="leaf"><a href="/elite-series"
+                                                                                title="">Elite Series</a></li>
+                                                                        <li class="leaf"><a
+                                                                                href="/major-disc-golf-events"
+                                                                                title="">Major Events</a></li>
+                                                                        <li class="leaf"><a href="/worlds">World
+                                                                                Championships</a></li>
+                                                                        <li class="last leaf"><a href="/td"
+                                                                                title="">Tournament Directors</a></li>
+                                                                    </ul>
+                                                                </li>
+                                                                <li class="expanded">
+                                                                    <div class="nolink" tabindex="0">Media</div>
+                                                                    <ul class="menu">
+                                                                        <li class="first leaf"><a
+                                                                                href="/discgolfer-magazine"
+                                                                                title="">DiscGolfer Magazine</a></li>
+                                                                        <li class="leaf"><a href="/radio" title="">PDGA
+                                                                                Radio</a></li>
+                                                                        <li class="leaf"><a href="/videos"
+                                                                                title="">Videos</a></li>
+                                                                        <li class="leaf"><a
+                                                                                href="https://www.facebook.com/pdga"
+                                                                                title="">Facebook</a></li>
+                                                                        <li class="leaf"><a
+                                                                                href="https://instagram.com/pdga"
+                                                                                title="">Instagram</a></li>
+                                                                        <li class="last leaf"><a
+                                                                                href="https://twitter.com/pdga"
+                                                                                title="">Twitter</a></li>
+                                                                    </ul>
+                                                                </li>
+                                                                <li class="last expanded">
+                                                                    <div class="nolink" tabindex="0">More</div>
+                                                                    <ul class="menu">
+                                                                        <li class="first leaf"><a href="/contact"
+                                                                                title="">Contact</a></li>
+                                                                        <li class="leaf"><a
+                                                                                href="/international">International</a>
+                                                                        </li>
+                                                                        <li class="leaf"><a
+                                                                                href="https://mailchi.mp/pdga/subscribe"
+                                                                                title="">Subscribe for Updates</a></li>
+                                                                        <li class="leaf"><a href="/tos">Terms of Use</a>
+                                                                        </li>
+                                                                        <li class="last leaf"><a href="/privacy">Privacy
+                                                                                Policy</a></li>
+                                                                    </ul>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+
+
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="grid-12 region region-footer-second" id="region-footer-second">
+                        <div class="region-inner region-footer-second-inner">
+                            <div class="block block-panels-mini block-footer-secondary block-panels-mini-footer-secondary odd block-without-title"
+                                id="block-panels-mini-footer-secondary">
+                                <div class="block-inner clearfix">
+
+                                    <div class="content clearfix">
+                                        <div class="panel-display panel-1col clearfix" id="mini-panel-footer_secondary">
+                                            <div class="panel-panel panel-col">
+                                                <div>
+                                                    <div class="panel-pane pane-pdga-architecture-footer"
+                                                        class="panel-pane pane-pdga-architecture-footer">
+
+
+
+                                                        <div class="pane-content">
+                                                            <p>Copyright © 1998-2025. Professional Disc Golf
+                                                                Association. All Rights Reserved.</p>
+                                                            <p>3828 Dogwood Lane, Appling, GA, USA 30802-3012 &mdash;
+                                                                Phone:&nbsp;+1-706-261-6342</p>
+                                                        </div>
+
+
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </footer>
+    </div>
+    <div class="region region-page-bottom" id="region-page-bottom">
+        <div class="region-inner region-page-bottom-inner">
+        </div>
+    </div>
+    <script type="5093243ad95d540811482c94-text/javascript">
+<!--//-->
+    <![CDATA[//><!--
+window.eu_cookie_compliance_cookie_name = "";
+//--><!]]>
+    </script>
+    <script type="5093243ad95d540811482c94-text/javascript"
+        src="https://www.pdga.com/files/js/js_9Rus79ChiI2hXGY4ky82J2TDHJZsnYE02SAHZrAw2QQ.js"></script>
+    <script src="/cdn-cgi/scripts/7d0fa10a/cloudflare-static/rocket-loader.min.js"
+        data-cf-settings="5093243ad95d540811482c94-|49" defer></script>
+    <script defer
+        src="https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015"
+        integrity="sha512-ZpsOmlRQV6y907TI0dKBHq9Md29nnaEIPlkf84rnaERnq6zvWvPUqr2ft8M1aS28oN72PdrCzSjY4U6VaAw1EQ=="
+        data-cf-beacon='{"rayId":"912899a11bba0f83","serverTiming":{"name":{"cfExtPri":true,"cfL4":true,"cfSpeedBrain":true,"cfCacheStatus":true}},"version":"2025.1.0","token":"e095cf69ec15493d973187ff31ae48df"}'
+        crossorigin="anonymous"></script>
+</body>
+
+</html>

--- a/src/testing/event_search_testing.ipynb
+++ b/src/testing/event_search_testing.ipynb
@@ -1,0 +1,76 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bs4 import BeautifulSoup\n",
+    "from requests import get\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = \"https://www.pdga.com/tour/search?date_filter[min][date]=2023-02-01&State[]=PA&Tier[]=A&Tier[]=B&Tier[]=C\"\n",
+    "page = get(url)\n",
+    "soup = BeautifulSoup(page.content, \"html.parser\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "next_page = soup.find(\"li\", attrs={\"class\":\"pager-next\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/tour/search?date_filter%5Bmin%5D%5Bdate%5D=2023-02-01&State%5B0%5D=PA&Tier%5B0%5D=A&Tier%5B1%5D=B&Tier%5B2%5D=C&page=1'"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "next_page.a['href']"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pdge_ratings",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
If more than 25 event were returned, everything after the 25th was ignore. This update checks if more results are available and submits a request to get them. 
This is done in a recursive manner which AWS does not like. Also a bit scary because if done wrong, I can end up with a massive AWS bill. considering to make this a local function in the future. 